### PR TITLE
feat(android): build and publish an APK on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
-# Builds the Windows app and publishes it as a GitHub Release.
+# Builds the Windows app and the Android APK, then publishes them as a GitHub
+# Release.
 #
 # It runs only when you push a version tag like "v0.1.0" — see how to do that
-# in the README's "Cutting a release" section.
+# in the README's "Cutting a release" section. Both jobs upload to the same
+# release for the tag.
 
 name: Release
 
@@ -49,4 +51,26 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: igpsport-intervals-windows.zip
+          generate_release_notes: true
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      # flet build apk auto-installs the Flutter SDK, the Android SDK and a JDK
+      # on first run. Output lands in build/apk/. The APK is debug-signed by
+      # default, which is installable for sideloading; for a store-grade signed
+      # build, add [tool.flet.android.signing] + a keystore in GitHub secrets.
+      - name: Build Android APK
+        run: uv run flet build apk --yes --verbose
+
+      - name: Publish Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/apk/*.apk
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Your password and API key are stored in your operating system's **secure
 credential store** — Windows Credential Manager on Windows (the same vault
 Windows uses for its own logins) — never in a plain text file.
 
+## Download & run (Android)
+
+1. On the [Releases](../../releases) page, download the latest `.apk`.
+2. Open it on your phone. Android will ask you to allow installing from this
+   source — accept (Settings → "Install unknown apps" for your browser/files app).
+3. Open the app, fill in **Settings** (same fields as above), and **Sync**.
+
+On Android your credentials are stored in the **Android Keystore**. The app
+isn't on the Play Store, so the "unknown source" prompt is expected.
+
 ## Run from source
 
 Requires [uv](https://docs.astral.sh/uv/).
@@ -45,11 +55,13 @@ git tag v0.1.0      # pick the next version number
 git push origin v0.1.0
 ```
 
-The workflow builds the Windows app on a clean runner, zips it, and attaches
-`igpsport-intervals-windows.zip` to a new GitHub Release. Watch it run under the
-repo's **Actions** tab; the result appears under **Releases**.
+The workflow builds the Windows app **and the Android APK** on clean runners and
+attaches both (`igpsport-intervals-windows.zip` and an `.apk`) to a new GitHub
+Release. Watch it run under the repo's **Actions** tab; the result appears under
+**Releases**.
 
 ## Roadmap
 
-The app is built with [Flet](https://flet.dev), so the same Python code can later
-be packaged for **Android** (`flet build apk`) and **iOS** (`flet build ipa`).
+The app is built with [Flet](https://flet.dev), so the same Python code targets
+desktop and Android today, with **iOS** (`flet build ipa`) possible from the same
+code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,10 @@ packages = ["src/igpsync"]
 # Used by `flet build`. The product name shown to end users.
 product = "iGPSPORT to intervals.icu"
 company = "igpsport-intervals"
+# Reverse-DNS app identifier (Android package / iOS bundle id). No hyphens
+# allowed in the segments. Change if you fork.
+bundle_id = "io.github.jorgehuxley.igpsync"
+
+# Android permissions baked into AndroidManifest.xml by `flet build apk`.
+[tool.flet.android.permission]
+"android.permission.INTERNET" = true

--- a/src/igpsync/gui/app.py
+++ b/src/igpsync/gui/app.py
@@ -11,15 +11,21 @@ from .settings_view import build_settings_view
 from .sync_view import build_sync_view
 
 
+_DESKTOP = {ft.PagePlatform.WINDOWS, ft.PagePlatform.MACOS, ft.PagePlatform.LINUX}
+
+
 async def _app(page: ft.Page) -> None:
     page.title = "iGPSPORT → intervals.icu"
     page.theme_mode = ft.ThemeMode.SYSTEM
     page.theme = ft.Theme(color_scheme_seed=ft.Colors.INDIGO)
     page.dark_theme = ft.Theme(color_scheme_seed=ft.Colors.INDIGO)
-    page.window.width = 560
-    page.window.height = 720
-    page.window.min_width = 420
     page.padding = 0
+
+    # Window sizing only applies on desktop; on mobile the app fills the screen.
+    if page.platform in _DESKTOP:
+        page.window.width = 560
+        page.window.height = 720
+        page.window.min_width = 420
 
     config = config_module.load()
 


### PR DESCRIPTION
## Summary
Adds the first Android build path for the app: a CI job builds an APK on every
release tag and attaches it to the GitHub Release, alongside the existing Windows
zip. Also adapts the GUI to behave correctly on a phone.

This is the build-enablement step of the Android plan — it produces an installable
APK so device-specific behaviour (download storage, etc.) can be refined later with
real feedback.

## Changes
- **CI:** new `android` job in `release.yml` runs `flet build apk` on a clean runner
  and attaches the `.apk` to the tag's release (Flet auto-installs the Flutter/Android
  SDK on first run).
- **Build config:** set the app `bundle_id` (`io.github.jorgehuxley.igpsync`) and
  declared the `INTERNET` permission in `pyproject.toml`.
- **GUI:** window sizing (`page.window.*`) is now guarded to desktop platforms, so the
  app fills the screen on Android/iOS instead of sizing a non-existent window.
- **Docs:** README gains Android download/install instructions.

## Verification
- ✅ Desktop app still launches with the platform guard (verified on Windows).
- ✅ `pyproject.toml` parses with the new config; all 22 tests pass.
- ⚠️ The APK build runs only in CI on a tag (it can't build locally due to a space in
  the dev's home path), so the first real validation is the release run.
- ⚠️ Install and on-device behaviour need a physical Android device.

## Notes / follow-ups
- The APK is **debug-signed** (installable for sideloading). Store-grade signing via
  `[tool.flet.android.signing]` + a keystore in GitHub secrets can be added later.
- **Deferred:** making the downloads folder user-accessible on Android — intentionally
  left until we can test on a device.