### PR TITLE
feat: tag-driven versioning, About dialog, and update-on-launch check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
 
+      # The git tag is the single source of truth for the version. Strip the
+      # leading "v" (v0.2.1 -> 0.2.1) for flet's x.y.z build-version.
+      - name: Compute version from tag
+        shell: bash
+        run: echo "APP_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      # Stamp it into the app so the in-app About dialog shows the real version.
+      - name: Stamp version into the app
+        shell: bash
+        run: echo "__version__ = \"$APP_VERSION\"" > src/igpsync/_version.py
+
       - name: Build Windows app
-        run: uv run flet build windows --yes --verbose
+        run: uv run flet build windows --yes --verbose --build-version "${{ env.APP_VERSION }}"
 
       # Name the zip after the tag, e.g. igpsport-intervals-v0.2.0-windows.zip
       - name: Package into a versioned zip
@@ -47,11 +58,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
 
+      - name: Compute version from tag
+        run: echo "APP_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Stamp version into the app
+        run: echo "__version__ = \"$APP_VERSION\"" > src/igpsync/_version.py
+
       # flet build apk auto-installs the Flutter/Android SDK + JDK on first run.
       # The APK is debug-signed (installable for sideloading); for store-grade
       # signing add [tool.flet.android.signing] + a keystore in GitHub secrets.
       - name: Build Android APK
-        run: uv run flet build apk --yes --verbose
+        run: uv run flet build apk --yes --verbose --build-version "${{ env.APP_VERSION }}"
 
       - name: Rename APK with the version
         run: mv build/apk/*.apk "igpsport-intervals-${{ github.ref_name }}-android.apk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.13"
 dependencies = [
     "flet>=0.28",
     "flet-secure-storage>=0.85.2",
+    "packaging>=26.2",
     "platformdirs>=4.0",
     "requests>=2.33.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "igpsport-intervals"
-version = "0.1.0"
+# Placeholder. The real version comes from the git tag, injected by CI at build
+# time (see .github/workflows/release.yml). Local/dev builds report 0.0.0+dev.
+version = "0.0.0"
 description = "Export cycling activities from iGPSPORT and upload them to intervals.icu"
 readme = "README.md"
 license = "MIT"

--- a/src/igpsync/__init__.py
+++ b/src/igpsync/__init__.py
@@ -1,3 +1,5 @@
 """igpsync — export iGPSPORT activities and upload them to intervals.icu."""
 
-__version__ = "0.1.0"
+from ._version import __version__
+
+__all__ = ["__version__"]

--- a/src/igpsync/_version.py
+++ b/src/igpsync/_version.py
@@ -1,0 +1,8 @@
+"""Single source of the app version at runtime.
+
+Local/dev keeps the placeholder below. CI overwrites this file with the git tag
+just before building (see .github/workflows/release.yml), so released builds
+report their real version (used by the in-app About dialog).
+"""
+
+__version__ = "0.0.0+dev"

--- a/src/igpsync/gui/app.py
+++ b/src/igpsync/gui/app.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import flet as ft
 from flet_secure_storage import SecureStorage
 
+from .. import __version__
 from .. import config as config_module
 from .. import secrets as secrets_module
 from .settings_view import build_settings_view
@@ -63,6 +64,28 @@ async def _app(page: ft.Page) -> None:
         )
         page.update()
 
+    def show_about(_: ft.ControlEvent | None = None) -> None:
+        page.show_dialog(
+            ft.AlertDialog(
+                title=ft.Text("About"),
+                content=ft.Column(
+                    tight=True,
+                    spacing=6,
+                    controls=[
+                        ft.Text("iGPSPORT → intervals.icu", weight=ft.FontWeight.BOLD),
+                        ft.Text(f"Version {__version__}"),
+                    ],
+                ),
+                actions=[
+                    ft.TextButton(
+                        "GitHub",
+                        url="https://github.com/jorge-huxley/igpsport-intervals",
+                    ),
+                    ft.TextButton("Close", on_click=lambda _: page.pop_dialog()),
+                ],
+            )
+        )
+
     page.appbar = ft.AppBar(
         title=ft.Text("iGPSPORT → intervals.icu"),
         center_title=False,
@@ -70,6 +93,7 @@ async def _app(page: ft.Page) -> None:
         actions=[
             ft.IconButton(ft.Icons.SYNC, tooltip="Sync", on_click=show_sync),
             ft.IconButton(ft.Icons.SETTINGS, tooltip="Settings", on_click=show_settings),
+            ft.IconButton(ft.Icons.INFO_OUTLINE, tooltip="About", on_click=show_about),
         ],
     )
 

--- a/src/igpsync/gui/app.py
+++ b/src/igpsync/gui/app.py
@@ -12,6 +12,7 @@ from flet_secure_storage import SecureStorage
 from .. import __version__
 from .. import config as config_module
 from .. import secrets as secrets_module
+from ..update_check import RELEASES_PAGE, check_for_update
 from .settings_view import build_settings_view
 from .sync_view import build_sync_view
 
@@ -104,6 +105,23 @@ async def _app(page: ft.Page) -> None:
         await show_sync()
     else:
         await show_settings()
+
+    # Quietly check GitHub for a newer release (off the UI thread; no-op on
+    # dev builds, silent on any error).
+    def _check_updates() -> None:
+        latest = check_for_update(__version__)
+        if latest:
+            page.show_dialog(
+                ft.SnackBar(
+                    content=ft.Text(f"Update available: v{latest}"),
+                    action="View",
+                    on_action=lambda _: page.launch_url(RELEASES_PAGE),
+                    duration=8000,
+                )
+            )
+            page.update()
+
+    page.run_thread(_check_updates)
 
 
 def main() -> None:

--- a/src/igpsync/update_check.py
+++ b/src/igpsync/update_check.py
@@ -1,0 +1,50 @@
+"""Check GitHub Releases for a newer version of the app.
+
+Pure logic, no UI. Fails silently (returns None) on any problem — offline, rate
+limited, parse errors — so it never disrupts launch.
+"""
+
+from __future__ import annotations
+
+import requests
+from packaging.version import InvalidVersion, Version
+
+REPO = "jorge-huxley/igpsport-intervals"
+LATEST_RELEASE_API = f"https://api.github.com/repos/{REPO}/releases/latest"
+RELEASES_PAGE = f"https://github.com/{REPO}/releases/latest"
+
+
+def check_for_update(current: str, timeout: float = 5.0) -> str | None:
+    """Return the latest release version (e.g. "0.2.3") if it is newer than
+    `current`, otherwise None. Returns None on any error or for dev builds.
+    """
+    try:
+        current_version = Version(current)
+    except InvalidVersion:
+        return None
+
+    # Dev/local builds (e.g. "0.0.0+dev") aren't real releases to compare.
+    if current_version.local or current_version.is_devrelease:
+        return None
+
+    try:
+        resp = requests.get(
+            LATEST_RELEASE_API,
+            timeout=timeout,
+            headers={"Accept": "application/vnd.github+json"},
+        )
+        resp.raise_for_status()
+        tag = resp.json().get("tag_name")
+    except (requests.RequestException, ValueError):
+        return None
+
+    if not tag:
+        return None
+
+    latest = tag.lstrip("v")
+    try:
+        if Version(latest) > current_version:
+            return latest
+    except InvalidVersion:
+        return None
+    return None

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,55 @@
+"""Tests for the GitHub release update check (offline; requests is faked)."""
+
+from __future__ import annotations
+
+from igpsync import update_check
+
+
+class FakeResponse:
+    def __init__(self, *, status=200, json_data=None):
+        self.status_code = status
+        self.ok = 200 <= status < 300
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise update_check.requests.HTTPError(f"HTTP {self.status_code}")
+
+
+def _fake_latest(tag):
+    return lambda *a, **k: FakeResponse(json_data={"tag_name": tag})
+
+
+def test_newer_release_returns_version(monkeypatch):
+    monkeypatch.setattr(update_check.requests, "get", _fake_latest("v0.3.0"))
+    assert update_check.check_for_update("0.2.0") == "0.3.0"
+
+
+def test_same_version_returns_none(monkeypatch):
+    monkeypatch.setattr(update_check.requests, "get", _fake_latest("v0.2.0"))
+    assert update_check.check_for_update("0.2.0") is None
+
+
+def test_older_release_returns_none(monkeypatch):
+    monkeypatch.setattr(update_check.requests, "get", _fake_latest("v0.1.0"))
+    assert update_check.check_for_update("0.2.0") is None
+
+
+def test_dev_build_skips_check(monkeypatch):
+    # Should not even hit the network for a dev/local build.
+    def boom(*a, **k):
+        raise AssertionError("network should not be called for dev builds")
+
+    monkeypatch.setattr(update_check.requests, "get", boom)
+    assert update_check.check_for_update("0.0.0+dev") is None
+
+
+def test_network_error_returns_none(monkeypatch):
+    def boom(*a, **k):
+        raise update_check.requests.ConnectionError("offline")
+
+    monkeypatch.setattr(update_check.requests, "get", boom)
+    assert update_check.check_for_update("0.2.0") is None

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "igpsport-intervals"
-version = "0.1.0"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "flet" },

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,7 @@ source = { editable = "." }
 dependencies = [
     { name = "flet" },
     { name = "flet-secure-storage" },
+    { name = "packaging" },
     { name = "platformdirs" },
     { name = "requests" },
 ]
@@ -182,6 +183,7 @@ dev = [
 requires-dist = [
     { name = "flet", specifier = ">=0.28" },
     { name = "flet-secure-storage", specifier = ">=0.85.2" },
+    { name = "packaging", specifier = ">=26.2" },
     { name = "platformdirs", specifier = ">=4.0" },
     { name = "requests", specifier = ">=2.33.1" },
 ]


### PR DESCRIPTION
## Summary
Make the git tag the single source of truth for the version, surface it in-app,
and notify users when a newer release exists.

## Changes
- ci: compute version from the tag → --build-version for Windows & Android, and
  stamp it into src/igpsync/_version.py (runner-only; repo stays 0.0.0+dev)
- feat(gui): About dialog (info icon) showing the version + repo link
- feat: check GitHub releases on launch; non-blocking snackbar if an update exists
- chore: pyproject version → 0.0.0 placeholder; add packaging dependency

## Verification
- [x] Tests pass (`uv run pytest`) — 27 passed
- [x] Desktop launches; About wired; update check is a silent no-op on dev builds
- [ ] Version string + update snackbar — confirm on the next tagged build

## Notes / follow-ups
- Update check hits GitHub's public releases API on launch (no auth); silent on
  errors/offline.