### PR TITLE
fix: make the update "View" button open the releases page

### DIFF
--- a/src/igpsync/gui/app.py
+++ b/src/igpsync/gui/app.py
@@ -66,8 +66,10 @@ async def _app(page: ft.Page) -> None:
         )
         page.update()
 
-    def open_releases(_: ft.ControlEvent) -> None:
-        page.launch_url(RELEASES_PAGE)
+    async def open_releases(_: ft.ControlEvent) -> None:
+        # page.launch_url is a coroutine in Flet 0.85 — it must be awaited,
+        # otherwise the "View" button silently does nothing.
+        await page.launch_url(RELEASES_PAGE)
 
     def notify_update(latest: str | None, *, quiet_when_current: bool) -> None:
         # Must run on the event loop (not a worker thread) so the snackbar's

--- a/src/igpsync/gui/app.py
+++ b/src/igpsync/gui/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import tempfile
 from pathlib import Path
@@ -65,6 +66,32 @@ async def _app(page: ft.Page) -> None:
         )
         page.update()
 
+    def open_releases(_: ft.ControlEvent) -> None:
+        page.launch_url(RELEASES_PAGE)
+
+    def notify_update(latest: str | None, *, quiet_when_current: bool) -> None:
+        # Must run on the event loop (not a worker thread) so the snackbar's
+        # action handler is wired up and the "View" button works.
+        if latest:
+            page.show_dialog(
+                ft.SnackBar(
+                    content=ft.Text(f"Update available: v{latest}"),
+                    action="View",
+                    on_action=open_releases,
+                    duration=8000,
+                )
+            )
+        elif not quiet_when_current:
+            page.show_dialog(ft.SnackBar(ft.Text("You're on the latest version.")))
+        page.update()
+
+    async def check_updates_now(_: ft.ControlEvent) -> None:
+        page.pop_dialog()  # close the About dialog
+        # allow_dev=True so it works on local/dev builds too (for testing): a
+        # 0.0.0 dev build counts as older than any published release.
+        latest = await asyncio.to_thread(check_for_update, __version__, allow_dev=True)
+        notify_update(latest, quiet_when_current=False)
+
     def show_about(_: ft.ControlEvent | None = None) -> None:
         page.show_dialog(
             ft.AlertDialog(
@@ -78,6 +105,7 @@ async def _app(page: ft.Page) -> None:
                     ],
                 ),
                 actions=[
+                    ft.TextButton("Check for updates", on_click=check_updates_now),
                     ft.TextButton(
                         "GitHub",
                         url="https://github.com/jorge-huxley/igpsport-intervals",
@@ -106,22 +134,15 @@ async def _app(page: ft.Page) -> None:
     else:
         await show_settings()
 
-    # Quietly check GitHub for a newer release (off the UI thread; no-op on
-    # dev builds, silent on any error).
-    def _check_updates() -> None:
-        latest = check_for_update(__version__)
-        if latest:
-            page.show_dialog(
-                ft.SnackBar(
-                    content=ft.Text(f"Update available: v{latest}"),
-                    action="View",
-                    on_action=lambda _: page.launch_url(RELEASES_PAGE),
-                    duration=8000,
-                )
-            )
-            page.update()
+    # Quietly check GitHub for a newer release. The network call runs in a
+    # thread (so it doesn't block the UI) but the snackbar is shown back on the
+    # event loop — otherwise its action handler isn't wired and "View" is dead.
+    # No-op on dev builds, silent on any error.
+    async def auto_check_updates() -> None:
+        latest = await asyncio.to_thread(check_for_update, __version__)
+        notify_update(latest, quiet_when_current=True)
 
-    page.run_thread(_check_updates)
+    page.run_task(auto_check_updates)
 
 
 def main() -> None:

--- a/src/igpsync/update_check.py
+++ b/src/igpsync/update_check.py
@@ -14,17 +14,22 @@ LATEST_RELEASE_API = f"https://api.github.com/repos/{REPO}/releases/latest"
 RELEASES_PAGE = f"https://github.com/{REPO}/releases/latest"
 
 
-def check_for_update(current: str, timeout: float = 5.0) -> str | None:
+def check_for_update(
+    current: str, timeout: float = 5.0, allow_dev: bool = False
+) -> str | None:
     """Return the latest release version (e.g. "0.2.3") if it is newer than
-    `current`, otherwise None. Returns None on any error or for dev builds.
+    `current`, otherwise None. Returns None on any error.
+
+    Dev/local builds (e.g. "0.0.0+dev") are skipped for the automatic check, but
+    `allow_dev=True` includes them — useful for a manual "Check for updates" so
+    the flow is testable without a tagged build.
     """
     try:
         current_version = Version(current)
     except InvalidVersion:
         return None
 
-    # Dev/local builds (e.g. "0.0.0+dev") aren't real releases to compare.
-    if current_version.local or current_version.is_devrelease:
+    if not allow_dev and (current_version.local or current_version.is_devrelease):
         return None
 
     try:

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -47,6 +47,12 @@ def test_dev_build_skips_check(monkeypatch):
     assert update_check.check_for_update("0.0.0+dev") is None
 
 
+def test_allow_dev_compares_dev_build(monkeypatch):
+    # With allow_dev, a 0.0.0 dev build is older than any real release.
+    monkeypatch.setattr(update_check.requests, "get", _fake_latest("v0.2.0"))
+    assert update_check.check_for_update("0.0.0+dev", allow_dev=True) == "0.2.0"
+
+
 def test_network_error_returns_none(monkeypatch):
     def boom(*a, **k):
         raise update_check.requests.ConnectionError("offline")


### PR DESCRIPTION
## Summary
The update snackbar's "View" button did nothing (Windows + Android). Fix the
event wiring and make the whole flow testable locally.

## Changes
- Show the update snackbar on the event loop (page.run_task + asyncio.to_thread)
  instead of from a background thread, so the action handler is wired and "View"
  opens the releases page
- Add a "Check for updates" button to the About dialog (allow_dev=True) so the
  flow can be tested from a dev build without compiling

## Verification
- [x] Tests pass (`uv run pytest`) — 28 passed
- [x] App launches; auto-check stays silent on dev
- [x] Manual "Check for updates" on dev returns the latest release (v0.2.4),
      so the snackbar shows and "View" can be exercised locally