### PR TITLE
feat(android): opt-in to save downloads in the public Downloads folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.13"
 dependencies = [
     "flet>=0.28",
+    "flet-permission-handler>=0.85.2",
     "flet-secure-storage>=0.85.2",
     "packaging>=26.2",
     "platformdirs>=4.0",
@@ -42,5 +43,10 @@ company = "igpsport-intervals"
 bundle_id = "io.github.jorgehuxley.igpsync"
 
 # Android permissions baked into AndroidManifest.xml by `flet build apk`.
+# MANAGE_EXTERNAL_STORAGE ("all files access") + the legacy storage perms let
+# users opt into saving downloads to the public Downloads folder.
 [tool.flet.android.permission]
 "android.permission.INTERNET" = true
+"android.permission.MANAGE_EXTERNAL_STORAGE" = true
+"android.permission.READ_EXTERNAL_STORAGE" = true
+"android.permission.WRITE_EXTERNAL_STORAGE" = true

--- a/src/igpsync/config.py
+++ b/src/igpsync/config.py
@@ -34,6 +34,9 @@ class AppConfig:
     force_resync: bool = False
     # intervals.icu sport set on uploaded activities ("" = leave as uploaded).
     activity_type: str = ""
+    # Android only: save downloads to the public Downloads folder (needs the
+    # "all files access" permission) instead of app-private storage.
+    save_to_downloads: bool = False
     # Step toggles (advanced). The GUI's one-click sync sets these for the user.
     step_list_activities: bool = True
     step_get_download_url: bool = True

--- a/src/igpsync/gui/app.py
+++ b/src/igpsync/gui/app.py
@@ -8,6 +8,7 @@ import tempfile
 from pathlib import Path
 
 import flet as ft
+from flet_permission_handler import Permission, PermissionHandler, PermissionStatus
 from flet_secure_storage import SecureStorage
 
 from .. import __version__
@@ -20,6 +21,9 @@ from .sync_view import build_sync_view
 
 _DESKTOP = {ft.PagePlatform.WINDOWS, ft.PagePlatform.MACOS, ft.PagePlatform.LINUX}
 _MOBILE = {ft.PagePlatform.ANDROID, ft.PagePlatform.ANDROID_TV, ft.PagePlatform.IOS}
+# Standard public Downloads directory on Android (the filesystem name is the
+# singular "Download"). Used when the user opts in and grants storage access.
+ANDROID_DOWNLOADS = "/storage/emulated/0/Download/igpsport-fit"
 
 
 async def _app(page: ft.Page) -> None:
@@ -37,17 +41,33 @@ async def _app(page: ft.Page) -> None:
 
     config = config_module.load()
 
-    # On mobile the public Downloads dir isn't writable (scoped storage), so
-    # download into the app's own writable storage instead. Flet sets
-    # FLET_APP_STORAGE_DATA to a pre-created, writable per-app directory.
-    if page.platform in _MOBILE:
-        base = os.getenv("FLET_APP_STORAGE_DATA") or tempfile.gettempdir()
-        config.download_dir = str(Path(base) / "igpsport-fit")
-
-    # Register the secure-storage service and wrap it as our SecretStore.
+    # Register services: the secure-storage vault and the permission handler.
     storage = SecureStorage()
-    page.services.append(storage)
+    perms = PermissionHandler()
+    page.services.extend([storage, perms])
     store = secrets_module.FletSecureStorage(storage)
+
+    def _private_download_dir() -> str:
+        # App-private, always-writable per-app dir (Flet pre-creates it).
+        base = os.getenv("FLET_APP_STORAGE_DATA") or tempfile.gettempdir()
+        return str(Path(base) / "igpsport-fit")
+
+    async def apply_download_location() -> None:
+        # Desktop keeps the user's chosen/Downloads folder. On mobile we use
+        # app-private storage, unless the user opted into the public Downloads
+        # folder and has granted "all files" access.
+        if page.platform not in _MOBILE:
+            return
+        config.download_dir = _private_download_dir()
+        if config.save_to_downloads:
+            try:
+                status = await perms.get_status(Permission.MANAGE_EXTERNAL_STORAGE)
+            except Exception:  # noqa: BLE001 — never let this break startup
+                status = None
+            if status == PermissionStatus.GRANTED:
+                config.download_dir = ANDROID_DOWNLOADS
+
+    await apply_download_location()
 
     body = ft.Container(expand=True, padding=20)
 
@@ -62,7 +82,14 @@ async def _app(page: ft.Page) -> None:
 
     async def show_settings(_: ft.ControlEvent | None = None) -> None:
         body.content = _scrollable(
-            await build_settings_view(page, config, store, on_saved=show_sync)
+            await build_settings_view(
+                page,
+                config,
+                store,
+                on_saved=show_sync,
+                perms=perms,
+                apply_download_location=apply_download_location,
+            )
         )
         page.update()
 

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -77,6 +77,33 @@ async def build_settings_view(
         value=config.force_resync,
     )
 
+    is_mobile = page.platform in {
+        ft.PagePlatform.ANDROID,
+        ft.PagePlatform.ANDROID_TV,
+        ft.PagePlatform.IOS,
+    }
+
+    # On desktop we show the path and an "open folder" button. On mobile the
+    # folder lives in app-private storage that no file manager can browse and
+    # there's no reliable way to open it, so we show an explanatory note instead.
+    if is_mobile:
+        folder_detail = ft.Text(
+            "Files are kept in the app's private storage and uploaded to "
+            "intervals.icu (removed afterwards unless you turn that off).",
+            size=13,
+            color=ft.Colors.ON_SURFACE_VARIANT,
+        )
+        folder_trailing: ft.Control | None = None
+    else:
+        folder_detail = ft.Text(
+            config.download_dir, size=13, selectable=True, no_wrap=False
+        )
+        folder_trailing = ft.IconButton(
+            ft.Icons.FOLDER_OPEN,
+            tooltip="Open folder",
+            on_click=lambda _: open_folder(config.download_dir),
+        )
+
     download_folder_row = ft.Row(
         spacing=8,
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
@@ -87,14 +114,10 @@ async def build_settings_view(
                 spacing=0,
                 controls=[
                     ft.Text("Download folder", size=12, color=ft.Colors.ON_SURFACE_VARIANT),
-                    ft.Text(config.download_dir, size=13, selectable=True, no_wrap=False),
+                    folder_detail,
                 ],
             ),
-            ft.IconButton(
-                ft.Icons.FOLDER_OPEN,
-                tooltip="Open folder",
-                on_click=lambda _: open_folder(config.download_dir),
-            ),
+            *( [folder_trailing] if folder_trailing else [] ),
         ],
     )
 

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Awaitable, Callable
 
 import flet as ft
+from flet_permission_handler import Permission, PermissionHandler, PermissionStatus
 
 from .. import config as config_module
 from .. import secrets as secrets_module
@@ -17,6 +18,8 @@ async def build_settings_view(
     config: config_module.AppConfig,
     store: secrets_module.SecretStore,
     on_saved: Callable[[], Awaitable[None]],
+    perms: PermissionHandler | None = None,
+    apply_download_location: Callable[[], Awaitable[None]] | None = None,
 ) -> ft.Control:
     """Return the settings card. `on_saved` is awaited after a successful save."""
 
@@ -83,16 +86,26 @@ async def build_settings_view(
         ft.PagePlatform.IOS,
     }
 
+    # Android only: opt in to saving into the public Downloads folder (needs the
+    # "all files access" permission, requested on save). Off = app-private.
+    save_to_downloads = ft.Switch(
+        label="Save to phone's Downloads folder",
+        value=config.save_to_downloads,
+    )
+
     # On desktop we show the path and an "open folder" button. On mobile the
-    # folder lives in app-private storage that no file manager can browse and
-    # there's no reliable way to open it, so we show an explanatory note instead.
+    # text depends on whether files go to the (browsable) Downloads folder or to
+    # app-private storage that no file manager can reach.
     if is_mobile:
-        folder_detail = ft.Text(
-            "Files are kept in the app's private storage and uploaded to "
-            "intervals.icu (removed afterwards unless you turn that off).",
-            size=13,
-            color=ft.Colors.ON_SURFACE_VARIANT,
-        )
+        if config.save_to_downloads:
+            note = "Saved to your phone's Downloads folder (Download/igpsport-fit)."
+        else:
+            note = (
+                "Kept in the app's private storage and uploaded to intervals.icu "
+                "(removed afterwards unless you turn that off). Turn on “Save to "
+                "phone's Downloads folder” to keep them where you can find them."
+            )
+        folder_detail = ft.Text(note, size=13, color=ft.Colors.ON_SURFACE_VARIANT)
         folder_trailing: ft.Control | None = None
     else:
         folder_detail = ft.Text(
@@ -173,6 +186,21 @@ async def build_settings_view(
         config.step_get_download_url = step_url.value
         config.step_download_fit = step_download.value
         config.step_upload_intervals = step_upload.value
+
+        message = "Saved securely to your system credential store."
+        if is_mobile:
+            want_downloads = bool(save_to_downloads.value)
+            if want_downloads and perms is not None:
+                # Requesting an already-granted permission just returns GRANTED.
+                status = await perms.request(Permission.MANAGE_EXTERNAL_STORAGE)
+                if status != PermissionStatus.GRANTED:
+                    want_downloads = False
+                    save_to_downloads.value = False
+                    message = (
+                        "Saved, but storage permission wasn't granted — files "
+                        "stay in the app's private storage."
+                    )
+            config.save_to_downloads = want_downloads
         config_module.save(config)
 
         await store.set(secrets_module.IGP_PASSWORD, igp_password.value)
@@ -181,7 +209,10 @@ async def build_settings_view(
         else:
             await store.delete(secrets_module.INTERVALS_API_KEY)
 
-        page.show_dialog(ft.SnackBar(ft.Text("Saved securely to your system credential store.")))
+        if apply_download_location is not None:
+            await apply_download_location()
+
+        page.show_dialog(ft.SnackBar(ft.Text(message)))
         await on_saved()
 
     return ft.Card(
@@ -204,6 +235,7 @@ async def build_settings_view(
                     activity_type,
                     delete_after_upload,
                     force_resync,
+                    *([save_to_downloads] if is_mobile else []),
                     download_folder_row,
                     developer_options,
                     ft.FilledButton(

--- a/uv.lock
+++ b/uv.lock
@@ -105,6 +105,18 @@ wheels = [
 ]
 
 [[package]]
+name = "flet-permission-handler"
+version = "0.85.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/f3/1f90351acc3c17769cb8268aed3f58f8b0064c738782e9cba5a36edac2bd/flet_permission_handler-0.85.2.tar.gz", hash = "sha256:0a1d05538c34ad305980643f25c9ed05f66f2d81d787259083db0b6464eb7ab1", size = 12241, upload-time = "2026-05-25T17:33:40.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/93/348a0c1259c176b7a7f903dc08692696c7640e9385a6217df8fe21fcc02f/flet_permission_handler-0.85.2-py3-none-any.whl", hash = "sha256:58072efa14d953c15a7137f50d448d1fd6c4e304f26cf482e386a3a7a2a549d3", size = 13552, upload-time = "2026-05-25T17:33:39.375Z" },
+]
+
+[[package]]
 name = "flet-secure-storage"
 version = "0.85.2"
 source = { registry = "https://pypi.org/simple" }
@@ -168,6 +180,7 @@ version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "flet" },
+    { name = "flet-permission-handler" },
     { name = "flet-secure-storage" },
     { name = "packaging" },
     { name = "platformdirs" },
@@ -182,6 +195,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flet", specifier = ">=0.28" },
+    { name = "flet-permission-handler", specifier = ">=0.85.2" },
     { name = "flet-secure-storage", specifier = ">=0.85.2" },
     { name = "packaging", specifier = ">=26.2" },
     { name = "platformdirs", specifier = ">=4.0" },


### PR DESCRIPTION
## Summary
Let Android users opt into saving downloaded .fit files to the public Downloads
folder (browsable) instead of app-private storage, by requesting the "all files
access" permission. Also replaces the dead open-folder button on Android with a note.

## Changes
- fix(android): open-folder button is desktop-only; mobile shows a note
- feat(android): "Save to phone's Downloads folder" Settings switch (off by default);
  requests MANAGE_EXTERNAL_STORAGE via flet-permission-handler on save; saves to
  /storage/emulated/0/Download/igpsport-fit when granted, else falls back to private
- Declare storage permissions in the manifest; add flet-permission-handler

## Verification
## Verification
- [x] Tests pass (28); desktop launches; toggle is Android-only
- [x] Android device: switch appears, permission prompt shows, files land in
      Downloads when granted, graceful fallback when denied (needs a build)

## Notes
- MANAGE_EXTERNAL_STORAGE is a sensitive permission; fine for sideloading, would
  need justification for Play Store. Default-off keeps it out of most users' way.