### PR TITLE
ci: mark pre-release tags and document release/hotfix flows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,14 @@ jobs:
       # Create (or update) the Release for this tag, attach both files, and
       # generate the notes a single time (avoids the duplicate notes you get
       # when each build job generates them).
+      #
+      # Tags with a hyphen (e.g. v0.3.0-rc1) are marked as pre-releases: GitHub
+      # keeps the last stable as "Latest", the in-app update check (which uses
+      # the /releases/latest API) ignores them, and they aren't offered to users.
       - name: Publish Release
         uses: softprops/action-gh-release@v2
         with:
           files: dist/**/*
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}

--- a/README.md
+++ b/README.md
@@ -87,11 +87,19 @@ the fix and tag a patch. If `master` already has work you're not ready to ship,
 branch the fix from the **last released tag** instead, so only the fix goes out:
 
 ```bash
-git switch -c hotfix/v0.2.5 v0.2.4   # branch from the released tag
-# ...make the fix, open a PR / merge it...
-git tag v0.2.5 && git push origin v0.2.5   # builds just the fix
-git switch master && git merge hotfix/v0.2.5   # bring the fix back into master
+# 1. Branch from the last released tag (NOT master):
+git switch -c hotfix/v0.2.5 v0.2.4
+# 2. Commit the fix on this branch, then push it:
+git push -u origin hotfix/v0.2.5
+# 3. Tag this branch's fix commit -> builds & publishes only the fix:
+git tag v0.2.5 && git push origin v0.2.5
+# 4. Open a PR from hotfix/v0.2.5 into master and merge it, so the fix is
+#    also in master for future work (master is protected, so use a PR).
 ```
+
+The tag points at the hotfix commit, so the build contains just the fix — none
+of master's unreleased work. The merge into master (step 4) is separate and
+happens *after* tagging.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ attaches both (`igpsport-intervals-windows.zip` and an `.apk`) to a new GitHub
 Release. Watch it run under the repo's **Actions** tab; the result appears under
 **Releases**.
 
+### Pre-releases (test a build before shipping)
+
+Tag with a hyphen, e.g. `v0.3.0-rc1`, to publish a **pre-release**. It still
+builds installable artifacts you can test on a device, but GitHub keeps the last
+stable as **Latest** and the in-app update check ignores it — so users on the
+stable version aren't notified. Once it's good, tag the final `v0.3.0`.
+
+### Urgent hotfix while `master` has unreleased work
+
+`master` only ever contains finished, merged PRs, so usually you can just merge
+the fix and tag a patch. If `master` already has work you're not ready to ship,
+branch the fix from the **last released tag** instead, so only the fix goes out:
+
+```bash
+git switch -c hotfix/v0.2.5 v0.2.4   # branch from the released tag
+# ...make the fix, open a PR / merge it...
+git tag v0.2.5 && git push origin v0.2.5   # builds just the fix
+git switch master && git merge hotfix/v0.2.5   # bring the fix back into master
+```
+
 ## Roadmap
 
 The app is built with [Flet](https://flet.dev), so the same Python code targets


### PR DESCRIPTION
## Summary
Make hyphenated tags (e.g. v0.3.0-rc1) publish as GitHub pre-releases, and
document the pre-release and hotfix workflows.

## Changes
- ci: release workflow marks v*-* tags as prerelease (and not "latest")
- docs: README sections for pre-release testing and hotfixes-from-a-tag

## Effect
- Pre-releases don't become "Latest" on GitHub and are excluded from the
  /releases/latest API, so the in-app update check won't offer them to users
  on the stable version
- Stable releases remain the "Latest" badge and the version users are notified about

## Verification
- [x] Tests pass (28)
- [ ] Confirm on next pre-release tag (e.g. v0.3.0-rc1) that it's marked
      pre-release and stable stays "Latest"