### PR TITLE
feat(dropbox): optional Dropbox upload as an independent target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Local development only. Copy to .env and run: uv run --env-file .env main.py
+#
+# Dropbox app key for the optional Dropbox upload. Create your own app at
+# https://www.dropbox.com/developers/apps (see CONTRIBUTING.md for scopes).
+# Leave blank to keep the Dropbox feature disabled. The .env file is gitignored.
+IGPSYNC_DROPBOX_APP_KEY=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,13 @@ jobs:
         shell: bash
         run: echo "__version__ = \"$APP_VERSION\"" > src/igpsync/_version.py
 
+      - name: Stamp Dropbox app key into the app
+        shell: pwsh
+        env:
+          IGPSYNC_DROPBOX_APP_KEY: ${{ secrets.IGPSYNC_DROPBOX_APP_KEY }}
+        run: |
+          python -c "from pathlib import Path; import os; Path('src/igpsync/_dropbox_app_key.py').write_text('DROPBOX_APP_KEY = ' + repr(os.getenv('IGPSYNC_DROPBOX_APP_KEY', '')) + '\n', encoding='utf-8')"
+
       - name: Build Windows app
         run: uv run flet build windows --yes --verbose --build-version "${{ env.APP_VERSION }}"
 
@@ -63,6 +70,12 @@ jobs:
 
       - name: Stamp version into the app
         run: echo "__version__ = \"$APP_VERSION\"" > src/igpsync/_version.py
+
+      - name: Stamp Dropbox app key into the app
+        env:
+          IGPSYNC_DROPBOX_APP_KEY: ${{ secrets.IGPSYNC_DROPBOX_APP_KEY }}
+        run: |
+          python -c "from pathlib import Path; import os; Path('src/igpsync/_dropbox_app_key.py').write_text('DROPBOX_APP_KEY = ' + repr(os.getenv('IGPSYNC_DROPBOX_APP_KEY', '')) + '\n', encoding='utf-8')"
 
       # Use a stable release key if the keystore secrets are configured, so every
       # release shares one signature and Android installs updates over the top

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,19 +59,17 @@ reusing the production one:
    an app with **Scoped access** and **App folder** access, and enable the
    `account_info.read`, `files.metadata.read`, and `files.content.write` scopes.
 2. Copy the app's **App key**.
-3. Set `IGPSYNC_DROPBOX_APP_KEY` before launching:
+3. Copy `.env.example` to `.env`, set `IGPSYNC_DROPBOX_APP_KEY` to your key, and
+   run with uv's `--env-file` flag (which loads the file into the environment):
 
    ```bash
-   IGPSYNC_DROPBOX_APP_KEY=your_app_key uv run main.py        # macOS/Linux
+   cp .env.example .env        # then edit .env and paste your app key
+   uv run --env-file .env main.py
    ```
 
-   ```powershell
-   $env:IGPSYNC_DROPBOX_APP_KEY = "your_app_key"; uv run main.py   # Windows
-   ```
-
-The app key for a PKCE public client isn't a secret (it ships inside released
-builds), but use your own for development so you don't share the production
-app's rate limit.
+`.env` is gitignored. The app key for a PKCE public client isn't a secret (it
+ships inside released builds), but use your own for development so you don't
+share the production app's rate limit.
 
 ## Making a change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@ Run the app while developing:
 
 ```bash
 uv run main.py          # launch the GUI
-uv run main.py --cli    # headless sync (reads .env / saved settings)
 ```
 
 ## Running the tests
@@ -44,6 +43,35 @@ minimal change (see `CLAUDE.md` for the full picture):
 - `src/igpsync/gui/` — the Flet UI; `cli.py` / `main.py` — the headless entry
 
 Keep new logic in `core` testable and UI-free; the GUI and CLI should stay thin.
+
+## Working on the Dropbox upload (optional)
+
+Dropbox is an optional, off-by-default upload target, so you only need to set
+this up if you're working on that feature — without a key the Dropbox switch in
+Settings stays disabled and the rest of the app works normally.
+
+The app authenticates with Dropbox using the **PKCE** OAuth flow, which needs a
+Dropbox **app key**. Releases get the key stamped in by CI from a repository
+secret. For local development, **create your own Dropbox app** rather than
+reusing the production one:
+
+1. In the [Dropbox App Console](https://www.dropbox.com/developers/apps), create
+   an app with **Scoped access** and **App folder** access, and enable the
+   `account_info.read`, `files.metadata.read`, and `files.content.write` scopes.
+2. Copy the app's **App key**.
+3. Set `IGPSYNC_DROPBOX_APP_KEY` before launching:
+
+   ```bash
+   IGPSYNC_DROPBOX_APP_KEY=your_app_key uv run main.py        # macOS/Linux
+   ```
+
+   ```powershell
+   $env:IGPSYNC_DROPBOX_APP_KEY = "your_app_key"; uv run main.py   # Windows
+   ```
+
+The app key for a PKCE public client isn't a secret (it ships inside released
+builds), but use your own for development so you don't share the production
+app's rate limit.
 
 ## Making a change
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.13"
 dependencies = [
+    "dropbox>=12.0.2",
     "flet>=0.28",
     "flet-permission-handler>=0.85.2",
     "flet-secure-storage>=0.85.2",

--- a/src/igpsync/_dropbox_app_key.py
+++ b/src/igpsync/_dropbox_app_key.py
@@ -1,0 +1,7 @@
+"""Build-stamped Dropbox app key.
+
+Release builds may overwrite this file from IGPSYNC_DROPBOX_APP_KEY. Local
+development can also use the IGPSYNC_DROPBOX_APP_KEY environment variable.
+"""
+
+DROPBOX_APP_KEY = ""

--- a/src/igpsync/config.py
+++ b/src/igpsync/config.py
@@ -30,7 +30,7 @@ class AppConfig:
     download_dir: str = field(default_factory=_default_download_dir)
     # Remove each .fit file once it has been uploaded to intervals.icu.
     delete_after_upload: bool = True
-    # Re-download/re-upload activities even if they are already on intervals.icu.
+    # Re-download/re-upload activities even if already on intervals.icu or Dropbox.
     force_resync: bool = False
     # intervals.icu sport set on uploaded activities ("" = leave as uploaded).
     activity_type: str = ""

--- a/src/igpsync/config.py
+++ b/src/igpsync/config.py
@@ -42,6 +42,10 @@ class AppConfig:
     step_get_download_url: bool = True
     step_download_fit: bool = True
     step_upload_intervals: bool = True
+    # Optional secondary upload target. Off by default because most users only
+    # want intervals.icu.
+    upload_dropbox: bool = False
+    dropbox_folder: str = "/igpsport-fit"
 
 
 def load() -> AppConfig:

--- a/src/igpsync/core.py
+++ b/src/igpsync/core.py
@@ -359,7 +359,7 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
             if config.upload_dropbox:
                 report(f"Uploading {act.ride_id} to Dropbox…")
                 try:
-                    dropbox_uploaded = upload_to_dropbox(
+                    upload_to_dropbox(
                         fit_path,
                         act.ride_id,
                         config.dropbox_refresh_token,
@@ -368,13 +368,11 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
                     )
                 except Exception as exc:  # noqa: BLE001 — surface provider failures
                     dropbox_uploaded = False
+                    result.failed_dropbox += 1
                     report(f"⚠ Dropbox upload failed for {act.ride_id}: {exc}")
-
-                if dropbox_uploaded:
+                else:
                     result.uploaded_dropbox += 1
                     report(f"✓ Uploaded {act.ride_id} to Dropbox")
-                else:
-                    result.failed_dropbox += 1
 
             if config.delete_after_upload and dropbox_uploaded:
                 fit_path.unlink(missing_ok=True)

--- a/src/igpsync/core.py
+++ b/src/igpsync/core.py
@@ -24,6 +24,8 @@ from urllib.parse import unquote
 
 import requests
 
+from .dropbox_client import DEFAULT_DROPBOX_FOLDER, upload_to_dropbox
+
 LOGIN_URL = "https://i.igpsport.com/Auth/Login"
 ACTIVITY_LIST_URL = "https://i.igpsport.com/Activity/ActivityList"
 GATEWAY = "https://prod.en.igpsport.com/service/web-gateway/web-analyze/activity"
@@ -81,8 +83,10 @@ class SyncResult:
     listed: int = 0
     downloaded: int = 0
     uploaded: int = 0
+    uploaded_dropbox: int = 0
     skipped: int = 0
     failed: int = 0
+    failed_dropbox: int = 0
     activities: list[Activity] = field(default_factory=list)
 
 
@@ -238,6 +242,8 @@ class SyncConfig:
     igp_user: str
     igp_password: str
     intervals_api_key: str | None
+    dropbox_refresh_token: str | None = None
+    dropbox_app_key: str | None = None
     max_activities: int = 5
     download_dir: Path = Path("downloads")
     delete_after_upload: bool = True
@@ -251,6 +257,8 @@ class SyncConfig:
     get_download_url: bool = False
     download_fit: bool = False
     upload_intervals: bool = False
+    upload_dropbox: bool = False
+    dropbox_folder: str = DEFAULT_DROPBOX_FOLDER
 
 
 def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
@@ -339,7 +347,33 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
                 else:
                     report(f"⚠ Could not set activity type for {act.ride_id}.")
 
-            if config.delete_after_upload:
+            dropbox_uploaded = True
+            if config.upload_dropbox:
+                if not config.dropbox_app_key:
+                    raise SyncError("Dropbox app key is required for Dropbox upload.")
+                if not config.dropbox_refresh_token:
+                    raise SyncError("Connect Dropbox in Settings before syncing.")
+
+                report(f"Uploading {act.ride_id} to Dropbox…")
+                try:
+                    dropbox_uploaded = upload_to_dropbox(
+                        fit_path,
+                        act.ride_id,
+                        config.dropbox_refresh_token,
+                        config.dropbox_app_key,
+                        config.dropbox_folder,
+                    )
+                except Exception as exc:  # noqa: BLE001 — surface provider failures
+                    dropbox_uploaded = False
+                    report(f"⚠ Dropbox upload failed for {act.ride_id}: {exc}")
+
+                if dropbox_uploaded:
+                    result.uploaded_dropbox += 1
+                    report(f"✓ Uploaded {act.ride_id} to Dropbox")
+                else:
+                    result.failed_dropbox += 1
+
+            if config.delete_after_upload and dropbox_uploaded:
                 fit_path.unlink(missing_ok=True)
                 report(f"  Removed local file {fit_path.name}")
         else:

--- a/src/igpsync/core.py
+++ b/src/igpsync/core.py
@@ -302,6 +302,14 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
         except requests.RequestException as exc:
             report(f"⚠ Could not check intervals.icu (will process all): {exc}")
 
+    # Validate Dropbox prerequisites once, before processing any activity, so a
+    # misconfiguration fails fast instead of part-way through the loop.
+    if config.upload_dropbox:
+        if not config.dropbox_app_key:
+            raise SyncError("Dropbox app key is required for Dropbox upload.")
+        if not config.dropbox_refresh_token:
+            raise SyncError("Connect Dropbox in Settings before syncing.")
+
     download_dir = Path(config.download_dir)
 
     for act in activities:
@@ -349,11 +357,6 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
 
             dropbox_uploaded = True
             if config.upload_dropbox:
-                if not config.dropbox_app_key:
-                    raise SyncError("Dropbox app key is required for Dropbox upload.")
-                if not config.dropbox_refresh_token:
-                    raise SyncError("Connect Dropbox in Settings before syncing.")
-
                 report(f"Uploading {act.ride_id} to Dropbox…")
                 try:
                     dropbox_uploaded = upload_to_dropbox(

--- a/src/igpsync/core.py
+++ b/src/igpsync/core.py
@@ -24,7 +24,11 @@ from urllib.parse import unquote
 
 import requests
 
-from .dropbox_client import DEFAULT_DROPBOX_FOLDER, upload_to_dropbox
+from .dropbox_client import (
+    DEFAULT_DROPBOX_FOLDER,
+    list_dropbox_ride_ids,
+    upload_to_dropbox,
+)
 
 LOGIN_URL = "https://i.igpsport.com/Auth/Login"
 ACTIVITY_LIST_URL = "https://i.igpsport.com/Activity/ActivityList"
@@ -85,6 +89,7 @@ class SyncResult:
     uploaded: int = 0
     uploaded_dropbox: int = 0
     skipped: int = 0
+    skipped_dropbox: int = 0
     failed: int = 0
     failed_dropbox: int = 0
     activities: list[Activity] = field(default_factory=list)
@@ -281,7 +286,10 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
             report(f"  • {act.ride_id} | {act.start_time} | {act.title}")
 
     needs_url = (
-        config.get_download_url or config.download_fit or config.upload_intervals
+        config.get_download_url
+        or config.download_fit
+        or config.upload_intervals
+        or config.upload_dropbox
     )
     if not needs_url:
         return result
@@ -304,20 +312,50 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
 
     # Validate Dropbox prerequisites once, before processing any activity, so a
     # misconfiguration fails fast instead of part-way through the loop.
+    dropbox_uploaded_ids: set[int] = set()
     if config.upload_dropbox:
         if not config.dropbox_app_key:
             raise SyncError("Dropbox app key is required for Dropbox upload.")
         if not config.dropbox_refresh_token:
             raise SyncError("Connect Dropbox in Settings before syncing.")
 
+        # Skip-tracking for Dropbox is independent of intervals.icu: list the
+        # ride ids already present in the folder so we don't re-upload them.
+        if not config.force_resync:
+            try:
+                dropbox_uploaded_ids = list_dropbox_ride_ids(
+                    config.dropbox_folder,
+                    config.dropbox_refresh_token,
+                    config.dropbox_app_key,
+                )
+                report(f"{len(dropbox_uploaded_ids)} activities already in Dropbox.")
+            except Exception as exc:  # noqa: BLE001 — non-fatal; process all
+                report(f"⚠ Could not check Dropbox (will process all): {exc}")
+
     download_dir = Path(config.download_dir)
 
-    for act in activities:
-        fit_path = download_dir / f"{external_id_for(act.ride_id)}.fit"
+    any_upload_enabled = config.upload_intervals or config.upload_dropbox
 
-        if external_id_for(act.ride_id) in already_uploaded:
+    for act in activities:
+        ext = external_id_for(act.ride_id)
+        fit_path = download_dir / f"{ext}.fit"
+
+        # Each target tracks its own "already there" state, so an activity can
+        # be uploaded to one target while being skipped on the other.
+        intervals_needs_it = config.upload_intervals and ext not in already_uploaded
+        dropbox_needs_it = (
+            config.upload_dropbox and act.ride_id not in dropbox_uploaded_ids
+        )
+
+        if config.upload_intervals and not intervals_needs_it:
             report(f"↷ Skipping {act.ride_id} — already on intervals.icu.")
             result.skipped += 1
+        if config.upload_dropbox and not dropbox_needs_it:
+            report(f"↷ Skipping {act.ride_id} — already in Dropbox.")
+            result.skipped_dropbox += 1
+
+        # Nothing left to do once every enabled upload target already has it.
+        if any_upload_enabled and not intervals_needs_it and not dropbox_needs_it:
             continue
 
         fit_url = resolve_fit_url(session, auth_headers, act.ride_id)
@@ -326,7 +364,9 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
             result.failed += 1
             continue
 
-        if config.get_download_url and not (config.download_fit or config.upload_intervals):
+        if config.get_download_url and not (
+            config.download_fit or config.upload_intervals or config.upload_dropbox
+        ):
             report(f"FIT URL for {act.ride_id}: {fit_url}")
             continue
 
@@ -334,51 +374,53 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
         download_fit(fit_url, fit_path)
         result.downloaded += 1
 
-        if not config.upload_intervals:
-            continue
+        intervals_ok = True
+        if intervals_needs_it:
+            if not config.intervals_api_key:
+                raise SyncError("intervals.icu API key is required for upload.")
 
-        if not config.intervals_api_key:
-            raise SyncError("intervals.icu API key is required for upload.")
+            activity_id = upload_to_intervals(
+                fit_path, act.title, act.ride_id, config.intervals_api_key
+            )
+            if activity_id:
+                report(f"✓ Uploaded {act.ride_id}: {act.title}")
+                result.uploaded += 1
 
-        activity_id = upload_to_intervals(
-            fit_path, act.title, act.ride_id, config.intervals_api_key
-        )
-        if activity_id:
-            report(f"✓ Uploaded {act.ride_id}: {act.title}")
-            result.uploaded += 1
+                if config.activity_type:
+                    if set_activity_type(
+                        activity_id, config.activity_type, config.intervals_api_key
+                    ):
+                        report(f"↻ Set {act.ride_id} → {config.activity_type}")
+                    else:
+                        report(f"⚠ Could not set activity type for {act.ride_id}.")
+            else:
+                report(f"✗ Failed to upload {act.ride_id}.")
+                result.failed += 1
+                intervals_ok = False
 
-            if config.activity_type:
-                if set_activity_type(
-                    activity_id, config.activity_type, config.intervals_api_key
-                ):
-                    report(f"↻ Set {act.ride_id} → {config.activity_type}")
-                else:
-                    report(f"⚠ Could not set activity type for {act.ride_id}.")
+        dropbox_ok = True
+        if dropbox_needs_it:
+            report(f"Uploading {act.ride_id} to Dropbox…")
+            try:
+                upload_to_dropbox(
+                    fit_path,
+                    act.ride_id,
+                    config.dropbox_refresh_token,
+                    config.dropbox_app_key,
+                    config.dropbox_folder,
+                )
+            except Exception as exc:  # noqa: BLE001 — surface provider failures
+                dropbox_ok = False
+                result.failed_dropbox += 1
+                report(f"⚠ Dropbox upload failed for {act.ride_id}: {exc}")
+            else:
+                result.uploaded_dropbox += 1
+                report(f"✓ Uploaded {act.ride_id} to Dropbox")
 
-            dropbox_uploaded = True
-            if config.upload_dropbox:
-                report(f"Uploading {act.ride_id} to Dropbox…")
-                try:
-                    upload_to_dropbox(
-                        fit_path,
-                        act.ride_id,
-                        config.dropbox_refresh_token,
-                        config.dropbox_app_key,
-                        config.dropbox_folder,
-                    )
-                except Exception as exc:  # noqa: BLE001 — surface provider failures
-                    dropbox_uploaded = False
-                    result.failed_dropbox += 1
-                    report(f"⚠ Dropbox upload failed for {act.ride_id}: {exc}")
-                else:
-                    result.uploaded_dropbox += 1
-                    report(f"✓ Uploaded {act.ride_id} to Dropbox")
-
-            if config.delete_after_upload and dropbox_uploaded:
-                fit_path.unlink(missing_ok=True)
-                report(f"  Removed local file {fit_path.name}")
-        else:
-            report(f"✗ Failed to upload {act.ride_id}.")
-            result.failed += 1
+        # Remove the local file only once every enabled target is satisfied, so
+        # a failure on either target keeps the file for a later retry.
+        if config.delete_after_upload and any_upload_enabled and intervals_ok and dropbox_ok:
+            fit_path.unlink(missing_ok=True)
+            report(f"  Removed local file {fit_path.name}")
 
     return result

--- a/src/igpsync/dropbox_client.py
+++ b/src/igpsync/dropbox_client.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 import dropbox
 from dropbox import DropboxOAuth2FlowNoRedirect
-from dropbox.files import WriteMode
+from dropbox.exceptions import ApiError
+from dropbox.files import FileMetadata, WriteMode
 
 from ._dropbox_app_key import DROPBOX_APP_KEY as BUILD_DROPBOX_APP_KEY
 
 DROPBOX_APP_KEY_ENV = "IGPSYNC_DROPBOX_APP_KEY"
 DEFAULT_DROPBOX_FOLDER = "/igpsport-fit"
+
+# Matches the FIT file names we write, e.g. "igpsport_12345.fit".
+_FIT_NAME_RE = re.compile(r"^igpsport_(\d+)\.fit$")
 
 
 def get_dropbox_app_key() -> str | None:
@@ -20,13 +25,17 @@ def get_dropbox_app_key() -> str | None:
     return os.getenv(DROPBOX_APP_KEY_ENV) or BUILD_DROPBOX_APP_KEY or None
 
 
+def normalize_folder(folder: str) -> str:
+    """Return a leading-slash, no-trailing-slash Dropbox folder path."""
+    clean = (folder or DEFAULT_DROPBOX_FOLDER).strip()
+    if not clean.startswith("/"):
+        clean = f"/{clean}"
+    return clean.rstrip("/")
+
+
 def dropbox_path_for(folder: str, ride_id: int) -> str:
     """Return the Dropbox app-folder path for an iGPSPORT ride."""
-    clean_folder = (folder or DEFAULT_DROPBOX_FOLDER).strip()
-    if not clean_folder.startswith("/"):
-        clean_folder = f"/{clean_folder}"
-    clean_folder = clean_folder.rstrip("/")
-    return f"{clean_folder}/igpsport_{ride_id}.fit"
+    return f"{normalize_folder(folder)}/igpsport_{ride_id}.fit"
 
 
 def start_dropbox_auth(app_key: str) -> tuple[DropboxOAuth2FlowNoRedirect, str]:
@@ -35,7 +44,12 @@ def start_dropbox_auth(app_key: str) -> tuple[DropboxOAuth2FlowNoRedirect, str]:
         app_key,
         use_pkce=True,
         token_access_type="offline",
-        scope=["account_info.read", "files.content.write"],
+        # files.metadata.read lets us list the folder to skip rides already there.
+        scope=[
+            "account_info.read",
+            "files.metadata.read",
+            "files.content.write",
+        ],
     )
     return auth_flow, auth_flow.start()
 
@@ -73,3 +87,39 @@ def upload_to_dropbox(
                 mode=WriteMode.overwrite,
                 mute=True,
             )
+
+
+def list_dropbox_ride_ids(
+    folder: str, refresh_token: str, app_key: str
+) -> set[int]:
+    """Return iGPSPORT ride ids that already have a FIT file in the folder.
+
+    Returns an empty set when the folder doesn't exist yet. Raises on other
+    Dropbox errors so the caller can decide whether to treat them as fatal.
+    """
+    base = normalize_folder(folder)
+    ride_ids: set[int] = set()
+    with dropbox.Dropbox(
+        oauth2_refresh_token=refresh_token,
+        app_key=app_key,
+        timeout=100,
+        user_agent="igpsport-intervals",
+    ) as dbx:
+        try:
+            result = dbx.files_list_folder(base)
+        except ApiError as exc:
+            if exc.error.is_path() and exc.error.get_path().is_not_found():
+                return ride_ids
+            raise
+        entries = list(result.entries)
+        while result.has_more:
+            result = dbx.files_list_folder_continue(result.cursor)
+            entries.extend(result.entries)
+
+    for entry in entries:
+        if not isinstance(entry, FileMetadata):
+            continue
+        match = _FIT_NAME_RE.match(entry.name)
+        if match:
+            ride_ids.add(int(match.group(1)))
+    return ride_ids

--- a/src/igpsync/dropbox_client.py
+++ b/src/igpsync/dropbox_client.py
@@ -10,6 +10,7 @@ import dropbox
 from dropbox import DropboxOAuth2FlowNoRedirect
 from dropbox.exceptions import ApiError
 from dropbox.files import FileMetadata, WriteMode
+from requests.exceptions import HTTPError
 
 from ._dropbox_app_key import DROPBOX_APP_KEY as BUILD_DROPBOX_APP_KEY
 
@@ -57,8 +58,20 @@ def start_dropbox_auth(app_key: str) -> tuple[DropboxOAuth2FlowNoRedirect, str]:
 def finish_dropbox_auth(
     auth_flow: DropboxOAuth2FlowNoRedirect, auth_code: str
 ) -> str | None:
-    """Finish OAuth and return the long-lived refresh token."""
-    result = auth_flow.finish(auth_code.strip())
+    """Finish OAuth and return the long-lived refresh token.
+
+    The Dropbox SDK calls ``raise_for_status()`` on the token request and drops
+    the response body, so a failed exchange surfaces only a generic
+    "400 Client Error". Re-raise with Dropbox's actual error text (e.g.
+    ``invalid_grant``) so the cause is visible to the user.
+    """
+    try:
+        result = auth_flow.finish(auth_code.strip())
+    except HTTPError as exc:
+        detail = ""
+        if exc.response is not None:
+            detail = exc.response.text.strip()
+        raise RuntimeError(f"{exc} — {detail}" if detail else str(exc)) from exc
     return result.refresh_token
 
 

--- a/src/igpsync/dropbox_client.py
+++ b/src/igpsync/dropbox_client.py
@@ -1,0 +1,73 @@
+"""Dropbox OAuth and upload helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import dropbox
+from dropbox import DropboxOAuth2FlowNoRedirect
+from dropbox.files import WriteMode
+
+from ._dropbox_app_key import DROPBOX_APP_KEY as BUILD_DROPBOX_APP_KEY
+
+DROPBOX_APP_KEY_ENV = "IGPSYNC_DROPBOX_APP_KEY"
+DEFAULT_DROPBOX_FOLDER = "/igpsport-fit"
+
+
+def get_dropbox_app_key() -> str | None:
+    """Return the Dropbox app key from env or the build-stamped constant."""
+    return os.getenv(DROPBOX_APP_KEY_ENV) or BUILD_DROPBOX_APP_KEY or None
+
+
+def dropbox_path_for(folder: str, ride_id: int) -> str:
+    """Return the Dropbox app-folder path for an iGPSPORT ride."""
+    clean_folder = (folder or DEFAULT_DROPBOX_FOLDER).strip()
+    if not clean_folder.startswith("/"):
+        clean_folder = f"/{clean_folder}"
+    clean_folder = clean_folder.rstrip("/")
+    return f"{clean_folder}/igpsport_{ride_id}.fit"
+
+
+def start_dropbox_auth(app_key: str) -> tuple[DropboxOAuth2FlowNoRedirect, str]:
+    """Start a PKCE OAuth flow and return the flow object plus auth URL."""
+    auth_flow = DropboxOAuth2FlowNoRedirect(
+        app_key,
+        use_pkce=True,
+        token_access_type="offline",
+        scope=["account_info.read", "files.content.write"],
+    )
+    return auth_flow, auth_flow.start()
+
+
+def finish_dropbox_auth(
+    auth_flow: DropboxOAuth2FlowNoRedirect, auth_code: str
+) -> str | None:
+    """Finish OAuth and return the long-lived refresh token."""
+    result = auth_flow.finish(auth_code.strip())
+    return result.refresh_token
+
+
+def upload_to_dropbox(
+    fit_path: Path,
+    ride_id: int,
+    refresh_token: str,
+    app_key: str,
+    folder: str = DEFAULT_DROPBOX_FOLDER,
+) -> bool:
+    """Upload a FIT file to Dropbox, overwriting the ride's existing file."""
+    target = dropbox_path_for(folder, ride_id)
+    with dropbox.Dropbox(
+        oauth2_refresh_token=refresh_token,
+        app_key=app_key,
+        timeout=100,
+        user_agent="igpsport-intervals",
+    ) as dbx:
+        with fit_path.open("rb") as f:
+            dbx.files_upload(
+                f.read(),
+                target,
+                mode=WriteMode.overwrite,
+                mute=True,
+            )
+    return True

--- a/src/igpsync/dropbox_client.py
+++ b/src/igpsync/dropbox_client.py
@@ -55,23 +55,34 @@ def start_dropbox_auth(app_key: str) -> tuple[DropboxOAuth2FlowNoRedirect, str]:
     return auth_flow, auth_flow.start()
 
 
+def _friendly_auth_error(exc: HTTPError) -> str:
+    """Turn a token-exchange HTTPError into a user-facing message.
+
+    The Dropbox SDK calls ``raise_for_status()`` and drops the response body,
+    so a failed exchange surfaces only a generic "400 Client Error". The most
+    common failure with the copy-paste flow is an expired/used code
+    (``invalid_grant``) — give that a friendly hint and fall back to Dropbox's
+    raw error text for anything unexpected.
+    """
+    body = ""
+    if exc.response is not None:
+        body = exc.response.text.strip()
+    if "invalid_grant" in body:
+        return (
+            "That authorization code expired or was already used. Tap "
+            "Connect Dropbox again and paste the new code quickly."
+        )
+    return f"{exc} — {body}" if body else str(exc)
+
+
 def finish_dropbox_auth(
     auth_flow: DropboxOAuth2FlowNoRedirect, auth_code: str
 ) -> str | None:
-    """Finish OAuth and return the long-lived refresh token.
-
-    The Dropbox SDK calls ``raise_for_status()`` on the token request and drops
-    the response body, so a failed exchange surfaces only a generic
-    "400 Client Error". Re-raise with Dropbox's actual error text (e.g.
-    ``invalid_grant``) so the cause is visible to the user.
-    """
+    """Finish OAuth and return the long-lived refresh token."""
     try:
         result = auth_flow.finish(auth_code.strip())
     except HTTPError as exc:
-        detail = ""
-        if exc.response is not None:
-            detail = exc.response.text.strip()
-        raise RuntimeError(f"{exc} — {detail}" if detail else str(exc)) from exc
+        raise RuntimeError(_friendly_auth_error(exc)) from exc
     return result.refresh_token
 
 

--- a/src/igpsync/dropbox_client.py
+++ b/src/igpsync/dropbox_client.py
@@ -54,8 +54,11 @@ def upload_to_dropbox(
     refresh_token: str,
     app_key: str,
     folder: str = DEFAULT_DROPBOX_FOLDER,
-) -> bool:
-    """Upload a FIT file to Dropbox, overwriting the ride's existing file."""
+) -> None:
+    """Upload a FIT file to Dropbox, overwriting the ride's existing file.
+
+    Raises on failure; a normal return means the upload succeeded.
+    """
     target = dropbox_path_for(folder, ride_id)
     with dropbox.Dropbox(
         oauth2_refresh_token=refresh_token,
@@ -70,4 +73,3 @@ def upload_to_dropbox(
                 mode=WriteMode.overwrite,
                 mute=True,
             )
-    return True

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -84,7 +84,7 @@ async def build_settings_view(
     )
 
     force_resync = ft.Switch(
-        label="Force re-sync (re-download even if already on intervals.icu)",
+        label="Force re-sync (re-download even if already on intervals.icu or in Dropbox)",
         value=config.force_resync,
     )
 

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -89,7 +89,7 @@ async def build_settings_view(
     )
 
     upload_dropbox = ft.Switch(
-        label="Upload to Dropbox after intervals.icu",
+        label="Upload activities to Dropbox",
         value=(
             config.upload_dropbox
             and bool(existing_dropbox_token)

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -10,6 +10,12 @@ from flet_permission_handler import Permission, PermissionHandler, PermissionSta
 from .. import config as config_module
 from .. import secrets as secrets_module
 from ..core import CYCLING_ACTIVITY_TYPES
+from ..dropbox_client import (
+    DEFAULT_DROPBOX_FOLDER,
+    finish_dropbox_auth,
+    get_dropbox_app_key,
+    start_dropbox_auth,
+)
 from .system import open_folder
 
 
@@ -26,6 +32,8 @@ async def build_settings_view(
     # Prefetch the currently-stored secrets to prefill the fields.
     existing_password = await store.get(secrets_module.IGP_PASSWORD) or ""
     existing_api_key = await store.get(secrets_module.INTERVALS_API_KEY) or ""
+    existing_dropbox_token = await store.get(secrets_module.DROPBOX_REFRESH_TOKEN)
+    dropbox_app_key = get_dropbox_app_key()
 
     igp_user = ft.TextField(
         label="iGPSPORT email",
@@ -78,6 +86,145 @@ async def build_settings_view(
     force_resync = ft.Switch(
         label="Force re-sync (re-download even if already on intervals.icu)",
         value=config.force_resync,
+    )
+
+    upload_dropbox = ft.Switch(
+        label="Upload to Dropbox after intervals.icu",
+        value=(
+            config.upload_dropbox
+            and bool(existing_dropbox_token)
+            and bool(dropbox_app_key)
+        ),
+        disabled=not bool(existing_dropbox_token and dropbox_app_key),
+    )
+    dropbox_folder = ft.TextField(
+        label="Dropbox folder",
+        value=config.dropbox_folder or DEFAULT_DROPBOX_FOLDER,
+        prefix_icon=ft.Icons.FOLDER,
+        helper="Inside this app's Dropbox folder",
+    )
+    dropbox_status = ft.Text(
+        (
+            "Connected"
+            if existing_dropbox_token and dropbox_app_key
+            else "Dropbox app key missing from this build"
+            if not dropbox_app_key
+            else "Not connected"
+        ),
+        size=13,
+        color=ft.Colors.ON_SURFACE_VARIANT,
+    )
+    dropbox_auth_code = ft.TextField(
+        label="Dropbox authorization code",
+        prefix_icon=ft.Icons.KEY,
+        visible=False,
+    )
+    dropbox_finish_button = ft.OutlinedButton(
+        "Finish connection",
+        icon=ft.Icons.CHECK,
+        visible=False,
+    )
+    dropbox_auth_flow = None
+
+    async def connect_dropbox(_: ft.ControlEvent) -> None:
+        nonlocal dropbox_auth_flow
+        if not dropbox_app_key:
+            page.show_dialog(
+                ft.SnackBar(ft.Text("Dropbox app key is missing from this build."))
+            )
+            return
+        dropbox_auth_flow, auth_url = start_dropbox_auth(dropbox_app_key)
+        dropbox_auth_code.visible = True
+        dropbox_finish_button.visible = True
+        dropbox_auth_code.value = ""
+        await page.launch_url(auth_url)
+        page.show_dialog(
+            ft.SnackBar(ft.Text("Paste the Dropbox authorization code here."))
+        )
+        page.update()
+
+    async def finish_dropbox(_: ft.ControlEvent) -> None:
+        nonlocal dropbox_auth_flow
+        if dropbox_auth_flow is None:
+            page.show_dialog(ft.SnackBar(ft.Text("Start Dropbox connection first.")))
+            return
+        if not dropbox_auth_code.value:
+            page.show_dialog(ft.SnackBar(ft.Text("Paste the Dropbox code first.")))
+            return
+        try:
+            refresh_token = finish_dropbox_auth(
+                dropbox_auth_flow, dropbox_auth_code.value
+            )
+        except Exception as exc:  # noqa: BLE001 — show auth failures directly
+            page.show_dialog(ft.SnackBar(ft.Text(f"Dropbox connection failed: {exc}")))
+            return
+        if not refresh_token:
+            page.show_dialog(
+                ft.SnackBar(ft.Text("Dropbox did not return a refresh token."))
+            )
+            return
+        await store.set(secrets_module.DROPBOX_REFRESH_TOKEN, refresh_token)
+        dropbox_auth_flow = None
+        dropbox_auth_code.visible = False
+        dropbox_finish_button.visible = False
+        dropbox_status.value = "Connected"
+        upload_dropbox.disabled = False
+        upload_dropbox.value = True
+        dropbox_disconnect_button.disabled = False
+        page.show_dialog(ft.SnackBar(ft.Text("Dropbox connected.")))
+        page.update()
+
+    async def disconnect_dropbox(_: ft.ControlEvent) -> None:
+        await store.delete(secrets_module.DROPBOX_REFRESH_TOKEN)
+        config.upload_dropbox = False
+        config_module.save(config)
+        upload_dropbox.value = False
+        upload_dropbox.disabled = True
+        dropbox_status.value = "Not connected"
+        page.show_dialog(ft.SnackBar(ft.Text("Dropbox disconnected.")))
+        page.update()
+
+    dropbox_connect_button = ft.OutlinedButton(
+        "Connect Dropbox",
+        icon=ft.Icons.CLOUD_UPLOAD,
+        disabled=not bool(dropbox_app_key),
+        on_click=connect_dropbox,
+    )
+    dropbox_disconnect_button = ft.TextButton(
+        "Disconnect",
+        icon=ft.Icons.LINK_OFF,
+        disabled=not bool(existing_dropbox_token),
+        on_click=disconnect_dropbox,
+    )
+    dropbox_finish_button.on_click = finish_dropbox
+
+    dropbox_options = ft.ExpansionTile(
+        title=ft.Text("Dropbox"),
+        leading=ft.Icon(ft.Icons.CLOUD),
+        affinity=ft.TileAffinity.LEADING,
+        expanded=config.upload_dropbox,
+        controls=[
+            ft.Container(
+                padding=ft.Padding(left=16, top=0, right=16, bottom=8),
+                content=ft.Column(
+                    spacing=8,
+                    controls=[
+                        dropbox_status,
+                        ft.Row(
+                            spacing=8,
+                            controls=[
+                                dropbox_connect_button,
+                                dropbox_disconnect_button,
+                            ],
+                        ),
+                        dropbox_auth_code,
+                        dropbox_finish_button,
+                        upload_dropbox,
+                        dropbox_folder,
+                    ],
+                ),
+            )
+        ],
     )
 
     is_mobile = page.platform in {
@@ -186,8 +333,20 @@ async def build_settings_view(
         config.step_get_download_url = step_url.value
         config.step_download_fit = step_download.value
         config.step_upload_intervals = step_upload.value
+        config.dropbox_folder = dropbox_folder.value.strip() or DEFAULT_DROPBOX_FOLDER
+        config.upload_dropbox = bool(upload_dropbox.value)
 
         message = "Saved securely to your system credential store."
+        if config.upload_dropbox and not dropbox_app_key:
+            config.upload_dropbox = False
+            upload_dropbox.value = False
+            message = "Saved, but Dropbox is disabled because this build has no app key."
+        elif config.upload_dropbox and not await store.get(
+            secrets_module.DROPBOX_REFRESH_TOKEN
+        ):
+            config.upload_dropbox = False
+            upload_dropbox.value = False
+            message = "Saved, but Dropbox is disabled until you connect it."
         if is_mobile:
             want_downloads = bool(save_to_downloads.value)
             if want_downloads and perms is not None:
@@ -235,6 +394,7 @@ async def build_settings_view(
                     activity_type,
                     delete_after_upload,
                     force_resync,
+                    dropbox_options,
                     *([save_to_downloads] if is_mobile else []),
                     download_folder_row,
                     developer_options,

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -84,7 +84,7 @@ async def build_settings_view(
     )
 
     force_resync = ft.Switch(
-        label="Force re-sync (re-download even if already on intervals.icu or in Dropbox)",
+        label="Force re-sync (re-download even if already uploaded)",
         value=config.force_resync,
     )
 

--- a/src/igpsync/gui/sync_view.py
+++ b/src/igpsync/gui/sync_view.py
@@ -7,6 +7,7 @@ import flet as ft
 from .. import config as config_module
 from .. import secrets as secrets_module
 from ..core import SyncConfig, SyncError, sync
+from ..dropbox_client import get_dropbox_app_key
 
 
 def build_sync_view(
@@ -29,13 +30,20 @@ def build_sync_view(
         # fills in step by step rather than all at once when the sync ends.
         page.update()
 
-    def run_sync(igp_password: str, api_key: str | None) -> None:
+    def run_sync(
+        igp_password: str,
+        api_key: str | None,
+        dropbox_refresh_token: str | None,
+        dropbox_app_key: str | None,
+    ) -> None:
         # Secrets are resolved on the async side and passed in, because the
         # secret store is async/page-bound and this runs on a worker thread.
         sync_config = SyncConfig(
             igp_user=config.igp_user,
             igp_password=igp_password,
             intervals_api_key=api_key,
+            dropbox_refresh_token=dropbox_refresh_token,
+            dropbox_app_key=dropbox_app_key,
             max_activities=config.max_activities,
             download_dir=config.download_dir,
             delete_after_upload=config.delete_after_upload,
@@ -45,13 +53,17 @@ def build_sync_view(
             get_download_url=config.step_get_download_url,
             download_fit=config.step_download_fit,
             upload_intervals=config.step_upload_intervals,
+            upload_dropbox=config.upload_dropbox,
+            dropbox_folder=config.dropbox_folder,
         )
 
         try:
             result = sync(sync_config, progress=append_log)
             append_log(
-                f"\nDone — uploaded {result.uploaded}, skipped {result.skipped}, "
-                f"downloaded {result.downloaded}, failed {result.failed}."
+                f"\nDone — intervals uploaded {result.uploaded}, "
+                f"Dropbox uploaded {result.uploaded_dropbox}, "
+                f"skipped {result.skipped}, downloaded {result.downloaded}, "
+                f"failed {result.failed}, Dropbox failed {result.failed_dropbox}."
             )
         except SyncError as exc:
             append_log(f"✗ {exc}")
@@ -68,6 +80,8 @@ def build_sync_view(
             page.show_dialog(ft.SnackBar(ft.Text("Add your credentials in Settings first.")))
             return
         api_key = await store.get(secrets_module.INTERVALS_API_KEY)
+        dropbox_refresh_token = await store.get(secrets_module.DROPBOX_REFRESH_TOKEN)
+        dropbox_app_key = get_dropbox_app_key()
 
         log.controls.clear()
         progress.visible = True
@@ -75,7 +89,13 @@ def build_sync_view(
         page.update()
         # Run off the UI thread (via Flet's managed executor) so the window
         # stays responsive and per-step updates flush to the client live.
-        page.run_thread(run_sync, igp_password, api_key)
+        page.run_thread(
+            run_sync,
+            igp_password,
+            api_key,
+            dropbox_refresh_token,
+            dropbox_app_key,
+        )
 
     sync_button.on_click = on_sync_click
 

--- a/src/igpsync/gui/sync_view.py
+++ b/src/igpsync/gui/sync_view.py
@@ -62,7 +62,8 @@ def build_sync_view(
             append_log(
                 f"\nDone — intervals uploaded {result.uploaded}, "
                 f"Dropbox uploaded {result.uploaded_dropbox}, "
-                f"skipped {result.skipped}, downloaded {result.downloaded}, "
+                f"downloaded {result.downloaded}, "
+                f"skipped {result.skipped}, Dropbox skipped {result.skipped_dropbox}, "
                 f"failed {result.failed}, Dropbox failed {result.failed_dropbox}."
             )
         except SyncError as exc:

--- a/src/igpsync/secrets.py
+++ b/src/igpsync/secrets.py
@@ -18,6 +18,7 @@ from flet_secure_storage import SecureStorage
 # Logical secret keys.
 IGP_PASSWORD = "igp_password"
 INTERVALS_API_KEY = "intervals_api_key"
+DROPBOX_REFRESH_TOKEN = "dropbox_refresh_token"
 
 
 class SecretStore(ABC):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,8 @@ def test_defaults():
     assert cfg.force_resync is False
     assert cfg.activity_type == ""  # "" = leave the uploaded sport untouched
     assert cfg.max_activities == 5
+    assert cfg.upload_dropbox is False
+    assert cfg.dropbox_folder == "/igpsport-fit"
 
 
 def test_save_and_load_roundtrip(tmp_path, monkeypatch):
@@ -24,6 +26,8 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
         max_activities=3,
         activity_type="GravelRide",
         delete_after_upload=False,
+        upload_dropbox=True,
+        dropbox_folder="/rides",
     )
     config_module.save(cfg)
     assert path.exists()
@@ -33,6 +37,8 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     assert loaded.max_activities == 3
     assert loaded.activity_type == "GravelRide"
     assert loaded.delete_after_upload is False
+    assert loaded.upload_dropbox is True
+    assert loaded.dropbox_folder == "/rides"
 
 
 def test_load_ignores_unknown_keys(tmp_path, monkeypatch):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,6 +143,7 @@ def stub_sync(monkeypatch, tmp_path):
         "dropbox": [],
         "typed": [],
         "existing": set(),
+        "dropbox_existing": set(),
         "dropbox_ok": True,
     }
 
@@ -181,6 +182,11 @@ def stub_sync(monkeypatch, tmp_path):
             raise RuntimeError("dropbox upload failed")
 
     monkeypatch.setattr(core, "upload_to_dropbox", fake_dropbox)
+    monkeypatch.setattr(
+        core,
+        "list_dropbox_ride_ids",
+        lambda folder, token, app_key: set(rec["dropbox_existing"]),
+    )
     monkeypatch.setattr(
         core,
         "set_activity_type",
@@ -273,20 +279,45 @@ def test_sync_uploads_to_dropbox_after_intervals(stub_sync):
     assert stub_sync["dropbox"][0][1:4] == ("dbx-refresh", "dbx-app", "/igpsport-fit")
 
 
-def test_sync_skips_dropbox_when_intervals_skip_applies(stub_sync):
+def test_sync_uploads_to_dropbox_even_when_intervals_skips(stub_sync):
+    # Already on intervals.icu, but not yet in Dropbox: the targets are
+    # independent, so all three still get pushed to Dropbox.
     stub_sync["existing"] = {"igpsport_1", "igpsport_2"}
     result = core.sync(_config(stub_sync["tmp"], upload_dropbox=True))
     assert result.skipped == 2
+    assert result.uploaded == 1
+    assert result.uploaded_dropbox == 3
+    assert [item[0] for item in stub_sync["dropbox"]] == [1, 2, 3]
+
+
+def test_sync_uploads_to_dropbox_when_intervals_disabled(stub_sync):
+    result = core.sync(
+        _config(stub_sync["tmp"], upload_intervals=False, upload_dropbox=True)
+    )
+    assert result.uploaded == 0
+    assert stub_sync["uploaded"] == []
+    assert result.uploaded_dropbox == 3
+    assert [item[0] for item in stub_sync["dropbox"]] == [1, 2, 3]
+
+
+def test_sync_skips_dropbox_for_rides_already_in_dropbox(stub_sync):
+    stub_sync["dropbox_existing"] = {1, 2}
+    result = core.sync(
+        _config(stub_sync["tmp"], upload_intervals=False, upload_dropbox=True)
+    )
+    assert result.skipped_dropbox == 2
     assert result.uploaded_dropbox == 1
     assert [item[0] for item in stub_sync["dropbox"]] == [3]
 
 
 def test_sync_force_resync_uploads_all_to_dropbox(stub_sync):
     stub_sync["existing"] = {"igpsport_1", "igpsport_2", "igpsport_3"}
+    stub_sync["dropbox_existing"] = {1, 2, 3}
     result = core.sync(
         _config(stub_sync["tmp"], force_resync=True, upload_dropbox=True)
     )
     assert result.skipped == 0
+    assert result.skipped_dropbox == 0
     assert result.uploaded_dropbox == 3
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,7 +137,14 @@ def test_login_raises_without_cookie(monkeypatch):
 @pytest.fixture
 def stub_sync(monkeypatch, tmp_path):
     """Replace every network leaf so sync() runs offline. Returns a recorder."""
-    rec = {"downloaded": [], "uploaded": [], "typed": [], "existing": set()}
+    rec = {
+        "downloaded": [],
+        "uploaded": [],
+        "dropbox": [],
+        "typed": [],
+        "existing": set(),
+        "dropbox_ok": True,
+    }
 
     monkeypatch.setattr(core, "login", lambda s, u, p: {"Authorization": "x"})
     monkeypatch.setattr(
@@ -167,6 +174,12 @@ def stub_sync(monkeypatch, tmp_path):
         return f"i{ride_id}"
 
     monkeypatch.setattr(core, "upload_to_intervals", fake_upload)
+
+    def fake_dropbox(fp, ride_id, token, app_key, folder):
+        rec["dropbox"].append((ride_id, token, app_key, folder, fp.name))
+        return rec["dropbox_ok"]
+
+    monkeypatch.setattr(core, "upload_to_dropbox", fake_dropbox)
     monkeypatch.setattr(
         core,
         "set_activity_type",
@@ -182,6 +195,8 @@ def _config(tmp_path, **overrides):
         igp_user="u",
         igp_password="p",
         intervals_api_key="k",
+        dropbox_refresh_token="dbx-refresh",
+        dropbox_app_key="dbx-app",
         download_dir=tmp_path,
         delete_after_upload=False,
         force_resync=False,
@@ -190,6 +205,8 @@ def _config(tmp_path, **overrides):
         get_download_url=False,
         download_fit=True,
         upload_intervals=True,
+        upload_dropbox=False,
+        dropbox_folder="/igpsport-fit",
     )
     base.update(overrides)
     return core.SyncConfig(**base)
@@ -240,3 +257,73 @@ def test_sync_deletes_file_after_upload_when_enabled(stub_sync):
 def test_sync_keeps_file_when_delete_disabled(stub_sync):
     core.sync(_config(stub_sync["tmp"], delete_after_upload=False))
     assert (stub_sync["tmp"] / "igpsport_1.fit").exists()
+
+
+def test_sync_does_not_upload_to_dropbox_when_disabled(stub_sync):
+    core.sync(_config(stub_sync["tmp"], upload_dropbox=False))
+    assert stub_sync["dropbox"] == []
+
+
+def test_sync_uploads_to_dropbox_after_intervals(stub_sync):
+    result = core.sync(_config(stub_sync["tmp"], upload_dropbox=True))
+    assert result.uploaded == 3
+    assert result.uploaded_dropbox == 3
+    assert [item[0] for item in stub_sync["dropbox"]] == [1, 2, 3]
+    assert stub_sync["dropbox"][0][1:4] == ("dbx-refresh", "dbx-app", "/igpsport-fit")
+
+
+def test_sync_skips_dropbox_when_intervals_skip_applies(stub_sync):
+    stub_sync["existing"] = {"igpsport_1", "igpsport_2"}
+    result = core.sync(_config(stub_sync["tmp"], upload_dropbox=True))
+    assert result.skipped == 2
+    assert result.uploaded_dropbox == 1
+    assert [item[0] for item in stub_sync["dropbox"]] == [3]
+
+
+def test_sync_force_resync_uploads_all_to_dropbox(stub_sync):
+    stub_sync["existing"] = {"igpsport_1", "igpsport_2", "igpsport_3"}
+    result = core.sync(
+        _config(stub_sync["tmp"], force_resync=True, upload_dropbox=True)
+    )
+    assert result.skipped == 0
+    assert result.uploaded_dropbox == 3
+
+
+def test_sync_keeps_file_when_dropbox_upload_fails(stub_sync):
+    stub_sync["dropbox_ok"] = False
+    result = core.sync(
+        _config(stub_sync["tmp"], delete_after_upload=True, upload_dropbox=True)
+    )
+    assert result.uploaded == 3
+    assert result.failed_dropbox == 3
+    assert (stub_sync["tmp"] / "igpsport_1.fit").exists()
+
+
+def test_sync_deletes_file_after_intervals_and_dropbox_when_enabled(stub_sync):
+    result = core.sync(
+        _config(stub_sync["tmp"], delete_after_upload=True, upload_dropbox=True)
+    )
+    assert result.uploaded_dropbox == 3
+    assert not (stub_sync["tmp"] / "igpsport_1.fit").exists()
+
+
+def test_sync_requires_dropbox_app_key_when_enabled(stub_sync):
+    with pytest.raises(core.SyncError, match="Dropbox app key"):
+        core.sync(
+            _config(
+                stub_sync["tmp"],
+                upload_dropbox=True,
+                dropbox_app_key=None,
+            )
+        )
+
+
+def test_sync_requires_dropbox_connection_when_enabled(stub_sync):
+    with pytest.raises(core.SyncError, match="Connect Dropbox"):
+        core.sync(
+            _config(
+                stub_sync["tmp"],
+                upload_dropbox=True,
+                dropbox_refresh_token=None,
+            )
+        )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -177,7 +177,8 @@ def stub_sync(monkeypatch, tmp_path):
 
     def fake_dropbox(fp, ride_id, token, app_key, folder):
         rec["dropbox"].append((ride_id, token, app_key, folder, fp.name))
-        return rec["dropbox_ok"]
+        if not rec["dropbox_ok"]:
+            raise RuntimeError("dropbox upload failed")
 
     monkeypatch.setattr(core, "upload_to_dropbox", fake_dropbox)
     monkeypatch.setattr(

--- a/tests/test_dropbox_client.py
+++ b/tests/test_dropbox_client.py
@@ -1,0 +1,13 @@
+"""Tests for Dropbox helper behavior. No live Dropbox calls are made."""
+
+from __future__ import annotations
+
+from igpsync.dropbox_client import dropbox_path_for
+
+
+def test_dropbox_path_uses_app_folder_subdirectory():
+    assert dropbox_path_for("/igpsport-fit", 123) == "/igpsport-fit/igpsport_123.fit"
+
+
+def test_dropbox_path_normalizes_folder():
+    assert dropbox_path_for("rides/", 7) == "/rides/igpsport_7.fit"

--- a/tests/test_dropbox_client.py
+++ b/tests/test_dropbox_client.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from igpsync.dropbox_client import dropbox_path_for
+import types
+
+from dropbox.exceptions import ApiError
+from dropbox.files import FileMetadata, FolderMetadata, ListFolderError
+from dropbox.files import LookupError as DbxLookupError
+
+from igpsync import dropbox_client
+from igpsync.dropbox_client import dropbox_path_for, list_dropbox_ride_ids
 
 
 def test_dropbox_path_uses_app_folder_subdirectory():
@@ -11,3 +18,67 @@ def test_dropbox_path_uses_app_folder_subdirectory():
 
 def test_dropbox_path_normalizes_folder():
     assert dropbox_path_for("rides/", 7) == "/rides/igpsport_7.fit"
+
+
+class _FakeDbx:
+    """Minimal stand-in for dropbox.Dropbox used as a context manager."""
+
+    def __init__(self, pages):
+        self._pages = pages
+        self._i = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def files_list_folder(self, path):
+        return self._pages[0]
+
+    def files_list_folder_continue(self, cursor):
+        self._i += 1
+        return self._pages[self._i]
+
+
+def _page(entries, has_more=False, cursor=""):
+    return types.SimpleNamespace(entries=entries, has_more=has_more, cursor=cursor)
+
+
+def test_list_dropbox_ride_ids_parses_fit_names(monkeypatch):
+    entries = [
+        FileMetadata(name="igpsport_1.fit"),
+        FileMetadata(name="igpsport_42.fit"),
+        FileMetadata(name="notes.txt"),  # ignored — wrong name
+        FolderMetadata(name="subfolder"),  # ignored — not a file
+    ]
+    monkeypatch.setattr(
+        dropbox_client.dropbox, "Dropbox", lambda **kw: _FakeDbx([_page(entries)])
+    )
+    assert list_dropbox_ride_ids("/igpsport-fit", "token", "key") == {1, 42}
+
+
+def test_list_dropbox_ride_ids_follows_pagination(monkeypatch):
+    pages = [
+        _page([FileMetadata(name="igpsport_1.fit")], has_more=True, cursor="c"),
+        _page([FileMetadata(name="igpsport_2.fit")]),
+    ]
+    monkeypatch.setattr(
+        dropbox_client.dropbox, "Dropbox", lambda **kw: _FakeDbx(pages)
+    )
+    assert list_dropbox_ride_ids("/igpsport-fit", "token", "key") == {1, 2}
+
+
+def test_list_dropbox_ride_ids_returns_empty_when_folder_missing(monkeypatch):
+    not_found = ApiError(
+        "rid", ListFolderError.path(DbxLookupError.not_found), "", ""
+    )
+
+    class _MissingDbx(_FakeDbx):
+        def files_list_folder(self, path):
+            raise not_found
+
+    monkeypatch.setattr(
+        dropbox_client.dropbox, "Dropbox", lambda **kw: _MissingDbx([])
+    )
+    assert list_dropbox_ride_ids("/igpsport-fit", "token", "key") == set()

--- a/tests/test_dropbox_client.py
+++ b/tests/test_dropbox_client.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import types
 
+import pytest
 from dropbox.exceptions import ApiError
 from dropbox.files import FileMetadata, FolderMetadata, ListFolderError
 from dropbox.files import LookupError as DbxLookupError
+from requests.exceptions import HTTPError
 
 from igpsync import dropbox_client
-from igpsync.dropbox_client import dropbox_path_for, list_dropbox_ride_ids
+from igpsync.dropbox_client import (
+    dropbox_path_for,
+    finish_dropbox_auth,
+    list_dropbox_ride_ids,
+)
 
 
 def test_dropbox_path_uses_app_folder_subdirectory():
@@ -82,3 +88,26 @@ def test_list_dropbox_ride_ids_returns_empty_when_folder_missing(monkeypatch):
         dropbox_client.dropbox, "Dropbox", lambda **kw: _MissingDbx([])
     )
     assert list_dropbox_ride_ids("/igpsport-fit", "token", "key") == set()
+
+
+class _FailingFlow:
+    """Stands in for the OAuth flow; finish() raises a token-exchange error."""
+
+    def __init__(self, body):
+        self._body = body
+
+    def finish(self, code):
+        resp = types.SimpleNamespace(text=self._body)
+        raise HTTPError("400 Client Error: Bad Request", response=resp)
+
+
+def test_finish_dropbox_auth_friendly_message_for_expired_code():
+    flow = _FailingFlow('{"error": "invalid_grant", "error_description": "..."}')
+    with pytest.raises(RuntimeError, match="expired or was already used"):
+        finish_dropbox_auth(flow, "somecode")
+
+
+def test_finish_dropbox_auth_falls_back_to_raw_error():
+    flow = _FailingFlow('{"error": "invalid_client"}')
+    with pytest.raises(RuntimeError, match="invalid_client"):
+        finish_dropbox_auth(flow, "somecode")

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -39,3 +39,7 @@ def test_fletsecurestorage_delegates():
         assert await store.get("k") is None
 
     asyncio.run(scenario())
+
+
+def test_dropbox_refresh_token_key_is_declared():
+    assert secrets_module.DROPBOX_REFRESH_TOKEN == "dropbox_refresh_token"

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,20 @@ wheels = [
 ]
 
 [[package]]
+name = "dropbox"
+version = "12.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "six" },
+    { name = "stone" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/56/ac085f58e8e0d0bcafdf98c2605e454ac946e3d0c72679669ae112dc30be/dropbox-12.0.2.tar.gz", hash = "sha256:50057fd5ad5fcf047f542dfc6747a896e7ef982f1b5f8500daf51f3abd609962", size = 560236, upload-time = "2024-06-03T16:45:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/de/95d8204d9a20fbdb353c5f8e4229b0fcb90f22b96f8246ff1f47c8a45fd5/dropbox-12.0.2-py3-none-any.whl", hash = "sha256:c5b7e9c2668adb6b12dcecd84342565dc50f7d35ab6a748d155cb79040979d1c", size = 572076, upload-time = "2024-06-03T16:45:28.153Z" },
+]
+
+[[package]]
 name = "flet"
 version = "0.85.2"
 source = { registry = "https://pypi.org/simple" }
@@ -179,6 +193,7 @@ name = "igpsport-intervals"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "dropbox" },
     { name = "flet" },
     { name = "flet-permission-handler" },
     { name = "flet-secure-storage" },
@@ -194,6 +209,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dropbox", specifier = ">=12.0.2" },
     { name = "flet", specifier = ">=0.28" },
     { name = "flet-permission-handler", specifier = ">=0.85.2" },
     { name = "flet-secure-storage", specifier = ">=0.85.2" },
@@ -286,6 +302,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -344,6 +369,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "stone"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ply" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/6f/ef25bbc1aefeb9c905d527f1d3cd3f41f22f40566d33001b8bb14ae0cdaf/stone-3.3.1.tar.gz", hash = "sha256:4ef0397512f609757975f7ec09b35639d72ba7e3e17ce4ddf399578346b4cb50", size = 190888, upload-time = "2022-01-25T21:32:16.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/92/d0c83f63d3518e5f0b8a311937c31347349ec9a47b209ddc17f7566f58fc/stone-3.3.1-py3-none-any.whl", hash = "sha256:e15866fad249c11a963cce3bdbed37758f2e88c8ff4898616bc0caeb1e216047", size = 162257, upload-time = "2022-01-25T21:32:15.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Body:

## What

Adds an **optional** Dropbox upload target alongside intervals.icu. Off by default — most users only want intervals.icu — but when enabled, each ride's `.fit` file is also pushed to a Dropbox app folder.

## Why

Some riders want a durable copy of their original `.fit` files (backup, or to feed other tools) in addition to intervals.icu.

## How it works

- **Independent of intervals.icu.** Dropbox isn't tied to a successful intervals upload — you can upload to Dropbox alone, and a ride already on intervals.icu still gets backed up to Dropbox.
- **Its own skip-tracking.** Before uploading, the app lists the FIT files already in the Dropbox folder (`igpsport_<id>.fit`) and skips those, so re-running is safe. `Force re-sync` bypasses both targets' skip checks.
- **Per-target counters** (`uploaded_dropbox`, `skipped_dropbox`, `failed_dropbox`) surfaced in the sync summary.
- **Safe deletes.** With "delete after upload" on, the local file is removed only once *every* enabled target succeeds — a failure on either keeps the file.
- **Auth.** PKCE OAuth (no app secret); the refresh token is stored in the OS secure vault like the other credentials. Connect/disconnect from Settings.

## Config / build

- The Dropbox **app key** is stamped into release builds from the `IGPSYNC_DROPBOX_APP_KEY` repo secret (`release.yml`); locally it's read from the same env var. Without a key, the Dropbox controls stay disabled and the rest of the app is unaffected.
- Adds the `files.metadata.read` OAuth scope (needed to list the folder for skip-tracking).

## Also in this PR

- Validate Dropbox credentials once before the sync loop (fail fast).
- `upload_to_dropbox` now signals failure via exceptions instead of a misleading always-`True` return.
- Docs: `.env.example` + CONTRIBUTING notes for local dev with your own Dropbox app; force re-sync label/wording clarified.

## Tests

`uv run pytest` — 44 passing. New coverage: independent upload (incl.
intervals-disabled), Dropbox skip-tracking, force-resync overriding both,
keep-file-on-failure, and `list_dropbox_ride_ids` (name parsing, pagination,
missing-folder → empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)