### PR TITLE
fix: paginate iGPSPORT ActivityList so max_activities is honored

### DIFF
--- a/src/igpsync/core.py
+++ b/src/igpsync/core.py
@@ -122,8 +122,14 @@ def login(session: requests.Session, user: str, password: str) -> dict[str, str]
 
 
 def list_activities(session: requests.Session, max_activities: int) -> list[Activity]:
-    """Return the most recent activities, newest first, capped at max_activities."""
-    resp = session.get(ACTIVITY_LIST_URL)
+    """Return the most recent activities, newest first, capped at max_activities.
+
+    ActivityList paginates: with no params it returns only the first page (10).
+    The endpoint honours pageSize, so we ask for the full page in one request
+    (pageNo navigation is unreliable). The slice is a safety belt in case the
+    server ever returns more than we asked for.
+    """
+    resp = session.get(ACTIVITY_LIST_URL, params={"pageNo": 1, "pageSize": max_activities})
     resp.raise_for_status()
 
     items = resp.json().get("item", [])[:max_activities]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -130,6 +130,35 @@ def test_login_raises_without_cookie(monkeypatch):
         core.login(FakeSession(), "user", "pass")
 
 
+def test_list_activities_requests_full_page_and_caps():
+    """pageSize is sent so we get more than the server's default 10, and the
+    result is still capped at max_activities as a safety belt."""
+    captured = {}
+
+    class FakeSession:
+        def get(self, url, params=None):
+            captured["url"] = url
+            captured["params"] = params
+            items = [{"RideId": i, "Title": f"Ride {i}", "StartTime": "2026-05-28 19:20:42"}
+                     for i in range(50)]
+            return FakeResponse(json_data={"item": items, "total": 59})
+
+    acts = core.list_activities(FakeSession(), 50)
+    assert captured["params"] == {"pageNo": 1, "pageSize": 50}
+    assert len(acts) == 50
+    assert acts[0].ride_id == 0
+
+
+def test_list_activities_caps_when_server_returns_extra():
+    class FakeSession:
+        def get(self, url, params=None):
+            items = [{"RideId": i, "Title": "", "StartTime": ""} for i in range(20)]
+            return FakeResponse(json_data={"item": items, "total": 20})
+
+    acts = core.list_activities(FakeSession(), 5)
+    assert len(acts) == 5
+
+
 # --------------------------------------------------------------------------- #
 # sync() orchestration
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

Setting `max_activities` higher than 10 still listed only 10 activities. `list_activities` called `ActivityList` with no query params, so iGPSPORT returned only its default first page of 10. The `[:max_activities]` slice can't produce more items than the server sends.

## Investigation

Probed the live endpoint (account has `total: 59` activities):

| Request | items returned |
|---|---|
| default (no params) | 10 |
| `pageNo=1 & pageSize=50` | **50** |
| `page=1 & size=50` | 10 (ignored) |
| `pageNo=2 & pageSize=10` | 10 (no advance) |

So the server honors `pageSize`, but `page`/`size` and `pageNo` navigation are ignored.

## Fix

Request a single full page with `pageNo=1` and `pageSize=max_activities`. The existing slice stays as a safety belt in case the server ever returns more than asked.

## Tests

Added two tests: one asserts the pagination params are sent and >10 activities come back; one verifies the cap still holds if the server over-returns. Full suite passes (48).

> Note: the server's max page size is unknown above this account's 59 activities (`pageSize=50` worked). If a much larger cap is ever needed, page navigation would have to be revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)