### PR TITLE
feat(dropbox): support custom folders and filename modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Requires [uv](https://docs.astral.sh/uv/).
 
 ```bash
 uv sync
-uv run main.py          # launch the app
+cp .env.example .env    # optional: set IGPSYNC_DROPBOX_APP_KEY for Dropbox
+uv run --env-file .env main.py
 ```
 
 ## Build the Windows executable

--- a/src/igpsync/config.py
+++ b/src/igpsync/config.py
@@ -46,6 +46,7 @@ class AppConfig:
     # want intervals.icu.
     upload_dropbox: bool = False
     dropbox_folder: str = "/igpsport-fit"
+    dropbox_date_filenames: bool = True
 
 
 def load() -> AppConfig:

--- a/src/igpsync/core.py
+++ b/src/igpsync/core.py
@@ -67,12 +67,15 @@ def external_id_for(ride_id: int) -> str:
     return f"igpsport_{ride_id}"
 
 
-def dropbox_filename_for(activity: "Activity") -> str:
+def dropbox_filename_for(activity: "Activity", use_date: bool = True) -> str:
     """Return the Dropbox filename for an activity."""
+    fallback = f"{external_id_for(activity.ride_id)}.fit"
+    if not use_date:
+        return fallback
     try:
         start = datetime.strptime(activity.start_time, IGP_TIME_FORMAT)
     except (TypeError, ValueError):
-        return f"{external_id_for(activity.ride_id)}.fit"
+        return fallback
     return f"ride-0-{start:%Y-%m-%d-%H-%M-%S}.fit"
 
 
@@ -279,6 +282,7 @@ class SyncConfig:
     upload_intervals: bool = False
     upload_dropbox: bool = False
     dropbox_folder: str = DEFAULT_DROPBOX_FOLDER
+    dropbox_date_filenames: bool = True
 
 
 def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
@@ -354,7 +358,7 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
     for act in activities:
         ext = external_id_for(act.ride_id)
         fit_path = download_dir / f"{ext}.fit"
-        dropbox_filename = dropbox_filename_for(act)
+        dropbox_filename = dropbox_filename_for(act, config.dropbox_date_filenames)
 
         # Each target tracks its own "already there" state, so an activity can
         # be uploaded to one target while being skipped on the other.

--- a/src/igpsync/core.py
+++ b/src/igpsync/core.py
@@ -26,7 +26,7 @@ import requests
 
 from .dropbox_client import (
     DEFAULT_DROPBOX_FOLDER,
-    list_dropbox_ride_ids,
+    list_dropbox_fit_names,
     upload_to_dropbox,
 )
 
@@ -65,6 +65,15 @@ CYCLING_ACTIVITY_TYPES: list[tuple[str, str]] = [
 def external_id_for(ride_id: int) -> str:
     """The intervals.icu external_id we assign to an iGPSPORT ride."""
     return f"igpsport_{ride_id}"
+
+
+def dropbox_filename_for(activity: "Activity") -> str:
+    """Return the Dropbox filename for an activity."""
+    try:
+        start = datetime.strptime(activity.start_time, IGP_TIME_FORMAT)
+    except (TypeError, ValueError):
+        return f"{external_id_for(activity.ride_id)}.fit"
+    return f"ride-0-{start:%Y-%m-%d-%H-%M-%S}.fit"
 
 
 class SyncError(Exception):
@@ -318,7 +327,7 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
 
     # Validate Dropbox prerequisites once, before processing any activity, so a
     # misconfiguration fails fast instead of part-way through the loop.
-    dropbox_uploaded_ids: set[int] = set()
+    dropbox_uploaded_names: set[str] = set()
     if config.upload_dropbox:
         if not config.dropbox_app_key:
             raise SyncError("Dropbox app key is required for Dropbox upload.")
@@ -326,15 +335,15 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
             raise SyncError("Connect Dropbox in Settings before syncing.")
 
         # Skip-tracking for Dropbox is independent of intervals.icu: list the
-        # ride ids already present in the folder so we don't re-upload them.
+        # FIT files already present in the folder so we don't re-upload them.
         if not config.force_resync:
             try:
-                dropbox_uploaded_ids = list_dropbox_ride_ids(
+                dropbox_uploaded_names = list_dropbox_fit_names(
                     config.dropbox_folder,
                     config.dropbox_refresh_token,
                     config.dropbox_app_key,
                 )
-                report(f"{len(dropbox_uploaded_ids)} activities already in Dropbox.")
+                report(f"{len(dropbox_uploaded_names)} activities already in Dropbox.")
             except Exception as exc:  # noqa: BLE001 — non-fatal; process all
                 report(f"⚠ Could not check Dropbox (will process all): {exc}")
 
@@ -345,12 +354,13 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
     for act in activities:
         ext = external_id_for(act.ride_id)
         fit_path = download_dir / f"{ext}.fit"
+        dropbox_filename = dropbox_filename_for(act)
 
         # Each target tracks its own "already there" state, so an activity can
         # be uploaded to one target while being skipped on the other.
         intervals_needs_it = config.upload_intervals and ext not in already_uploaded
         dropbox_needs_it = (
-            config.upload_dropbox and act.ride_id not in dropbox_uploaded_ids
+            config.upload_dropbox and dropbox_filename not in dropbox_uploaded_names
         )
 
         if config.upload_intervals and not intervals_needs_it:
@@ -410,7 +420,7 @@ def sync(config: SyncConfig, progress: Progress | None = None) -> SyncResult:
             try:
                 upload_to_dropbox(
                     fit_path,
-                    act.ride_id,
+                    dropbox_filename,
                     config.dropbox_refresh_token,
                     config.dropbox_app_key,
                     config.dropbox_folder,

--- a/src/igpsync/dropbox_client.py
+++ b/src/igpsync/dropbox_client.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import re
 from pathlib import Path
 
 import dropbox
@@ -16,10 +15,6 @@ from ._dropbox_app_key import DROPBOX_APP_KEY as BUILD_DROPBOX_APP_KEY
 
 DROPBOX_APP_KEY_ENV = "IGPSYNC_DROPBOX_APP_KEY"
 DEFAULT_DROPBOX_FOLDER = "/igpsport-fit"
-
-# Matches the FIT file names we write, e.g. "igpsport_12345.fit".
-_FIT_NAME_RE = re.compile(r"^igpsport_(\d+)\.fit$")
-
 
 def get_dropbox_app_key() -> str | None:
     """Return the Dropbox app key from env or the build-stamped constant."""
@@ -34,9 +29,9 @@ def normalize_folder(folder: str) -> str:
     return clean.rstrip("/")
 
 
-def dropbox_path_for(folder: str, ride_id: int) -> str:
-    """Return the Dropbox app-folder path for an iGPSPORT ride."""
-    return f"{normalize_folder(folder)}/igpsport_{ride_id}.fit"
+def dropbox_path_for(folder: str, filename: str) -> str:
+    """Return the Dropbox path for a FIT filename."""
+    return f"{normalize_folder(folder)}/{filename}"
 
 
 def start_dropbox_auth(app_key: str) -> tuple[DropboxOAuth2FlowNoRedirect, str]:
@@ -88,7 +83,7 @@ def finish_dropbox_auth(
 
 def upload_to_dropbox(
     fit_path: Path,
-    ride_id: int,
+    filename: str,
     refresh_token: str,
     app_key: str,
     folder: str = DEFAULT_DROPBOX_FOLDER,
@@ -97,7 +92,7 @@ def upload_to_dropbox(
 
     Raises on failure; a normal return means the upload succeeded.
     """
-    target = dropbox_path_for(folder, ride_id)
+    target = dropbox_path_for(folder, filename)
     with dropbox.Dropbox(
         oauth2_refresh_token=refresh_token,
         app_key=app_key,
@@ -113,16 +108,16 @@ def upload_to_dropbox(
             )
 
 
-def list_dropbox_ride_ids(
+def list_dropbox_fit_names(
     folder: str, refresh_token: str, app_key: str
-) -> set[int]:
-    """Return iGPSPORT ride ids that already have a FIT file in the folder.
+) -> set[str]:
+    """Return FIT filenames already present in the folder.
 
     Returns an empty set when the folder doesn't exist yet. Raises on other
     Dropbox errors so the caller can decide whether to treat them as fatal.
     """
     base = normalize_folder(folder)
-    ride_ids: set[int] = set()
+    fit_names: set[str] = set()
     with dropbox.Dropbox(
         oauth2_refresh_token=refresh_token,
         app_key=app_key,
@@ -133,7 +128,7 @@ def list_dropbox_ride_ids(
             result = dbx.files_list_folder(base)
         except ApiError as exc:
             if exc.error.is_path() and exc.error.get_path().is_not_found():
-                return ride_ids
+                return fit_names
             raise
         entries = list(result.entries)
         while result.has_more:
@@ -143,7 +138,6 @@ def list_dropbox_ride_ids(
     for entry in entries:
         if not isinstance(entry, FileMetadata):
             continue
-        match = _FIT_NAME_RE.match(entry.name)
-        if match:
-            ride_ids.add(int(match.group(1)))
-    return ride_ids
+        if entry.name.lower().endswith(".fit"):
+            fit_names.add(entry.name)
+    return fit_names

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -103,6 +103,10 @@ async def build_settings_view(
         prefix_icon=ft.Icons.FOLDER,
         helper="Dropbox path, e.g. /Fit files",
     )
+    dropbox_date_filenames = ft.Switch(
+        label="Use date in Dropbox filenames",
+        value=config.dropbox_date_filenames,
+    )
     dropbox_status = ft.Text(
         (
             "Connected"
@@ -221,6 +225,7 @@ async def build_settings_view(
                         dropbox_finish_button,
                         upload_dropbox,
                         dropbox_folder,
+                        dropbox_date_filenames,
                     ],
                 ),
             )
@@ -334,6 +339,7 @@ async def build_settings_view(
         config.step_download_fit = step_download.value
         config.step_upload_intervals = step_upload.value
         config.dropbox_folder = dropbox_folder.value.strip() or DEFAULT_DROPBOX_FOLDER
+        config.dropbox_date_filenames = bool(dropbox_date_filenames.value)
         config.upload_dropbox = bool(upload_dropbox.value)
 
         message = "Saved securely to your system credential store."

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -101,7 +101,7 @@ async def build_settings_view(
         label="Dropbox folder",
         value=config.dropbox_folder or DEFAULT_DROPBOX_FOLDER,
         prefix_icon=ft.Icons.FOLDER,
-        helper="Inside this app's Dropbox folder",
+        helper="Dropbox path, e.g. /Fit files",
     )
     dropbox_status = ft.Text(
         (

--- a/src/igpsync/gui/sync_view.py
+++ b/src/igpsync/gui/sync_view.py
@@ -55,6 +55,7 @@ def build_sync_view(
             upload_intervals=config.step_upload_intervals,
             upload_dropbox=config.upload_dropbox,
             dropbox_folder=config.dropbox_folder,
+            dropbox_date_filenames=config.dropbox_date_filenames,
         )
 
         try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ def test_defaults():
     assert cfg.max_activities == 5
     assert cfg.upload_dropbox is False
     assert cfg.dropbox_folder == "/igpsport-fit"
+    assert cfg.dropbox_date_filenames is True
 
 
 def test_save_and_load_roundtrip(tmp_path, monkeypatch):
@@ -28,6 +29,7 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
         delete_after_upload=False,
         upload_dropbox=True,
         dropbox_folder="/rides",
+        dropbox_date_filenames=False,
     )
     config_module.save(cfg)
     assert path.exists()
@@ -39,6 +41,7 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     assert loaded.delete_after_upload is False
     assert loaded.upload_dropbox is True
     assert loaded.dropbox_folder == "/rides"
+    assert loaded.dropbox_date_filenames is False
 
 
 def test_load_ignores_unknown_keys(tmp_path, monkeypatch):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,16 @@ def test_external_id_for():
     assert core.external_id_for(123) == "igpsport_123"
 
 
+def test_dropbox_filename_for_start_time():
+    act = core.Activity(1, "Ride", "2026-06-03 17:23:53")
+    assert core.dropbox_filename_for(act) == "ride-0-2026-06-03-17-23-53.fit"
+
+
+def test_dropbox_filename_falls_back_to_external_id_for_bad_start_time():
+    act = core.Activity(1, "Ride", "unknown date")
+    assert core.dropbox_filename_for(act) == "igpsport_1.fit"
+
+
 def test_activity_date_range_from_start_times():
     acts = [
         core.Activity(1, "a", "2026-05-20 10:00:00"),
@@ -205,15 +215,15 @@ def stub_sync(monkeypatch, tmp_path):
 
     monkeypatch.setattr(core, "upload_to_intervals", fake_upload)
 
-    def fake_dropbox(fp, ride_id, token, app_key, folder):
-        rec["dropbox"].append((ride_id, token, app_key, folder, fp.name))
+    def fake_dropbox(fp, filename, token, app_key, folder):
+        rec["dropbox"].append((filename, token, app_key, folder, fp.name))
         if not rec["dropbox_ok"]:
             raise RuntimeError("dropbox upload failed")
 
     monkeypatch.setattr(core, "upload_to_dropbox", fake_dropbox)
     monkeypatch.setattr(
         core,
-        "list_dropbox_ride_ids",
+        "list_dropbox_fit_names",
         lambda folder, token, app_key: set(rec["dropbox_existing"]),
     )
     monkeypatch.setattr(
@@ -304,8 +314,13 @@ def test_sync_uploads_to_dropbox_after_intervals(stub_sync):
     result = core.sync(_config(stub_sync["tmp"], upload_dropbox=True))
     assert result.uploaded == 3
     assert result.uploaded_dropbox == 3
-    assert [item[0] for item in stub_sync["dropbox"]] == [1, 2, 3]
+    assert [item[0] for item in stub_sync["dropbox"]] == [
+        "ride-0-2026-05-28-19-20-42.fit",
+        "ride-0-2026-05-26-18-47-06.fit",
+        "ride-0-2026-05-24-08-27-17.fit",
+    ]
     assert stub_sync["dropbox"][0][1:4] == ("dbx-refresh", "dbx-app", "/igpsport-fit")
+    assert stub_sync["dropbox"][0][4] == "igpsport_1.fit"
 
 
 def test_sync_uploads_to_dropbox_even_when_intervals_skips(stub_sync):
@@ -316,7 +331,11 @@ def test_sync_uploads_to_dropbox_even_when_intervals_skips(stub_sync):
     assert result.skipped == 2
     assert result.uploaded == 1
     assert result.uploaded_dropbox == 3
-    assert [item[0] for item in stub_sync["dropbox"]] == [1, 2, 3]
+    assert [item[0] for item in stub_sync["dropbox"]] == [
+        "ride-0-2026-05-28-19-20-42.fit",
+        "ride-0-2026-05-26-18-47-06.fit",
+        "ride-0-2026-05-24-08-27-17.fit",
+    ]
 
 
 def test_sync_uploads_to_dropbox_when_intervals_disabled(stub_sync):
@@ -326,22 +345,35 @@ def test_sync_uploads_to_dropbox_when_intervals_disabled(stub_sync):
     assert result.uploaded == 0
     assert stub_sync["uploaded"] == []
     assert result.uploaded_dropbox == 3
-    assert [item[0] for item in stub_sync["dropbox"]] == [1, 2, 3]
+    assert [item[0] for item in stub_sync["dropbox"]] == [
+        "ride-0-2026-05-28-19-20-42.fit",
+        "ride-0-2026-05-26-18-47-06.fit",
+        "ride-0-2026-05-24-08-27-17.fit",
+    ]
 
 
 def test_sync_skips_dropbox_for_rides_already_in_dropbox(stub_sync):
-    stub_sync["dropbox_existing"] = {1, 2}
+    stub_sync["dropbox_existing"] = {
+        "ride-0-2026-05-28-19-20-42.fit",
+        "ride-0-2026-05-26-18-47-06.fit",
+    }
     result = core.sync(
         _config(stub_sync["tmp"], upload_intervals=False, upload_dropbox=True)
     )
     assert result.skipped_dropbox == 2
     assert result.uploaded_dropbox == 1
-    assert [item[0] for item in stub_sync["dropbox"]] == [3]
+    assert [item[0] for item in stub_sync["dropbox"]] == [
+        "ride-0-2026-05-24-08-27-17.fit"
+    ]
 
 
 def test_sync_force_resync_uploads_all_to_dropbox(stub_sync):
     stub_sync["existing"] = {"igpsport_1", "igpsport_2", "igpsport_3"}
-    stub_sync["dropbox_existing"] = {1, 2, 3}
+    stub_sync["dropbox_existing"] = {
+        "ride-0-2026-05-28-19-20-42.fit",
+        "ride-0-2026-05-26-18-47-06.fit",
+        "ride-0-2026-05-24-08-27-17.fit",
+    }
     result = core.sync(
         _config(stub_sync["tmp"], force_resync=True, upload_dropbox=True)
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,6 +41,11 @@ def test_dropbox_filename_for_start_time():
     assert core.dropbox_filename_for(act) == "ride-0-2026-06-03-17-23-53.fit"
 
 
+def test_dropbox_filename_uses_default_name_when_date_disabled():
+    act = core.Activity(1, "Ride", "2026-06-03 17:23:53")
+    assert core.dropbox_filename_for(act, use_date=False) == "igpsport_1.fit"
+
+
 def test_dropbox_filename_falls_back_to_external_id_for_bad_start_time():
     act = core.Activity(1, "Ride", "unknown date")
     assert core.dropbox_filename_for(act) == "igpsport_1.fit"
@@ -253,6 +258,7 @@ def _config(tmp_path, **overrides):
         upload_intervals=True,
         upload_dropbox=False,
         dropbox_folder="/igpsport-fit",
+        dropbox_date_filenames=True,
     )
     base.update(overrides)
     return core.SyncConfig(**base)
@@ -352,6 +358,23 @@ def test_sync_uploads_to_dropbox_when_intervals_disabled(stub_sync):
     ]
 
 
+def test_sync_uploads_to_dropbox_with_default_filenames_when_configured(stub_sync):
+    result = core.sync(
+        _config(
+            stub_sync["tmp"],
+            upload_intervals=False,
+            upload_dropbox=True,
+            dropbox_date_filenames=False,
+        )
+    )
+    assert result.uploaded_dropbox == 3
+    assert [item[0] for item in stub_sync["dropbox"]] == [
+        "igpsport_1.fit",
+        "igpsport_2.fit",
+        "igpsport_3.fit",
+    ]
+
+
 def test_sync_skips_dropbox_for_rides_already_in_dropbox(stub_sync):
     stub_sync["dropbox_existing"] = {
         "ride-0-2026-05-28-19-20-42.fit",
@@ -365,6 +388,21 @@ def test_sync_skips_dropbox_for_rides_already_in_dropbox(stub_sync):
     assert [item[0] for item in stub_sync["dropbox"]] == [
         "ride-0-2026-05-24-08-27-17.fit"
     ]
+
+
+def test_sync_skips_dropbox_default_filenames_when_configured(stub_sync):
+    stub_sync["dropbox_existing"] = {"igpsport_1.fit", "igpsport_2.fit"}
+    result = core.sync(
+        _config(
+            stub_sync["tmp"],
+            upload_intervals=False,
+            upload_dropbox=True,
+            dropbox_date_filenames=False,
+        )
+    )
+    assert result.skipped_dropbox == 2
+    assert result.uploaded_dropbox == 1
+    assert [item[0] for item in stub_sync["dropbox"]] == ["igpsport_3.fit"]
 
 
 def test_sync_force_resync_uploads_all_to_dropbox(stub_sync):

--- a/tests/test_dropbox_client.py
+++ b/tests/test_dropbox_client.py
@@ -14,16 +14,17 @@ from igpsync import dropbox_client
 from igpsync.dropbox_client import (
     dropbox_path_for,
     finish_dropbox_auth,
-    list_dropbox_ride_ids,
+    list_dropbox_fit_names,
 )
 
 
 def test_dropbox_path_uses_app_folder_subdirectory():
-    assert dropbox_path_for("/igpsport-fit", 123) == "/igpsport-fit/igpsport_123.fit"
+    filename = "ride-0-2026-06-03-17-23-53.fit"
+    assert dropbox_path_for("/Fit files", filename) == f"/Fit files/{filename}"
 
 
 def test_dropbox_path_normalizes_folder():
-    assert dropbox_path_for("rides/", 7) == "/rides/igpsport_7.fit"
+    assert dropbox_path_for("rides/", "igpsport_7.fit") == "/rides/igpsport_7.fit"
 
 
 class _FakeDbx:
@@ -51,31 +52,37 @@ def _page(entries, has_more=False, cursor=""):
     return types.SimpleNamespace(entries=entries, has_more=has_more, cursor=cursor)
 
 
-def test_list_dropbox_ride_ids_parses_fit_names(monkeypatch):
+def test_list_dropbox_fit_names_returns_fit_files(monkeypatch):
     entries = [
         FileMetadata(name="igpsport_1.fit"),
-        FileMetadata(name="igpsport_42.fit"),
+        FileMetadata(name="ride-0-2026-06-03-17-23-53.fit"),
         FileMetadata(name="notes.txt"),  # ignored — wrong name
         FolderMetadata(name="subfolder"),  # ignored — not a file
     ]
     monkeypatch.setattr(
         dropbox_client.dropbox, "Dropbox", lambda **kw: _FakeDbx([_page(entries)])
     )
-    assert list_dropbox_ride_ids("/igpsport-fit", "token", "key") == {1, 42}
+    assert list_dropbox_fit_names("/igpsport-fit", "token", "key") == {
+        "igpsport_1.fit",
+        "ride-0-2026-06-03-17-23-53.fit",
+    }
 
 
-def test_list_dropbox_ride_ids_follows_pagination(monkeypatch):
+def test_list_dropbox_fit_names_follows_pagination(monkeypatch):
     pages = [
         _page([FileMetadata(name="igpsport_1.fit")], has_more=True, cursor="c"),
-        _page([FileMetadata(name="igpsport_2.fit")]),
+        _page([FileMetadata(name="ride-0-2026-06-03-17-23-53.fit")]),
     ]
     monkeypatch.setattr(
         dropbox_client.dropbox, "Dropbox", lambda **kw: _FakeDbx(pages)
     )
-    assert list_dropbox_ride_ids("/igpsport-fit", "token", "key") == {1, 2}
+    assert list_dropbox_fit_names("/igpsport-fit", "token", "key") == {
+        "igpsport_1.fit",
+        "ride-0-2026-06-03-17-23-53.fit",
+    }
 
 
-def test_list_dropbox_ride_ids_returns_empty_when_folder_missing(monkeypatch):
+def test_list_dropbox_fit_names_returns_empty_when_folder_missing(monkeypatch):
     not_found = ApiError(
         "rid", ListFolderError.path(DbxLookupError.not_found), "", ""
     )
@@ -87,7 +94,7 @@ def test_list_dropbox_ride_ids_returns_empty_when_folder_missing(monkeypatch):
     monkeypatch.setattr(
         dropbox_client.dropbox, "Dropbox", lambda **kw: _MissingDbx([])
     )
-    assert list_dropbox_ride_ids("/igpsport-fit", "token", "key") == set()
+    assert list_dropbox_fit_names("/igpsport-fit", "token", "key") == set()
 
 
 class _FailingFlow:


### PR DESCRIPTION
## Summary

Updates Dropbox uploads so the app can target user-chosen Dropbox paths such as /Fit files when the Dropbox app is configured with full Dropbox access. Also adds Dropbox filename options: users can keep default igpsport_<id>.fit names or use Android-style date names like ride-0-2026-06-03-17-23-53.fit, while local files keep their existing names.

Closes #18.

## Changes

- Dropbox folder/access behavior
  - Treats the Dropbox folder setting as the upload path entered by the user, e.g. /Fit files
  - Clarifies the Settings helper text from app-folder wording to Dropbox path wording
  - Supports the full-access Dropbox app setup needed for folders outside the app folder

- Dropbox filename behavior
  - Builds the Dropbox target filename separately from the local downloaded file path
  - Keeps local files named igpsport_<id>.fit
  - Adds a Settings switch to choose date-based Dropbox filenames or default filenames
  - Falls back to igpsport_<id>.fit if the activity start time cannot be parsed

- Dropbox skip tracking
  - Lists existing .fit filenames in Dropbox instead of extracting ride ids from igpsport_<id>.fit
  - Skips Dropbox uploads by comparing the configured expected filename
  - Keeps force re-sync behavior unchanged

- Local development docs
  - Updates README run-from-source instructions to use .env loading: uv run --env-file .env main.py

## Verification

- [x] Tests pass (uv run pytest) - 53 passed
- [x] Targeted Dropbox/config tests pass (uv run pytest tests/test_core.py tests/test_config.py tests/test_dropbox_client.py -q) - 45 passed
- [ ] Ruff check (uv run ruff check src tests) - not run: ruff is not installed in this environment

## Notes / follow-ups

- Dropbox apps used with /Fit files or other non-app-folder paths must be configured for full Dropbox access, not app-folder-only access.
