### PR TITLE
feat(cli): add agent-friendly headless sync entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ intervals.icu. Free and open source, for **Windows** and **Android**.
 - Stores your credentials in the **OS secure vault** (Windows Credential Manager / Android Keystore), never in a file
 - Lets you know when a newer version is available
 
-> Prefer the terminal, or want to help out? It's open source (Python + [Flet](https://flet.dev), MIT) — see [Run from source](#run-from-source) and [CONTRIBUTING.md](CONTRIBUTING.md).
+> Prefer the terminal, or want to help out? It's open source (Python + [Flet](https://flet.dev), MIT) — see [Run from source](#run-from-source), [Agent / headless sync](docs/AGENT.md), and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Download & run (Windows)
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1,0 +1,112 @@
+# Agent / headless sync
+
+Use the `igpsync` CLI to upload recent rides from iGPSPORT to intervals.icu
+without the GUI. It is designed for automation agents (e.g.
+[Hermes](https://hermes-agent.nousresearch.com)) that already detect new
+activities and only need a reliable upload trigger.
+
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) installed
+- This repository cloned locally
+- Dependencies installed: `uv sync`
+
+## User setup (human — not the agent)
+
+Agents cannot write secrets. The **user** must configure credentials once in
+their Hermes profile. Replace `{profile}` with the Hermes profile wrapper name
+(e.g. `hermes` for the default profile, or `coder` for a named profile):
+
+```bash
+{profile} config set IGPSYNC_IGP_USER you@example.com
+{profile} config set IGPSYNC_IGP_PASSWORD your-igpsport-password
+{profile} config set IGPSYNC_INTERVALS_API_KEY your-intervals-api-key
+```
+
+Hermes stores these in `{HERMES_HOME}/.env`. The CLI reads that file
+automatically when run under Hermes (via the `HERMES_HOME` environment
+variable). No skill or `env_passthrough` configuration is required.
+
+**intervals.icu API key:** intervals.icu → Settings → Developer.
+
+Verify setup:
+
+```bash
+uv run igpsync check
+```
+
+Optional: override the secrets file path in CLI config
+(`platformdirs.user_config_dir("igpsync-cli")/config.json`) with an `env_file`
+field, or pass `--env-file PATH` per invocation.
+
+## Agent invocation
+
+From the repository root:
+
+```bash
+uv run igpsync sync --json
+```
+
+- **Progress** is written to **stderr** (safe to ignore or log).
+- **Result** is a single JSON object on **stdout**.
+- **Exit code:** `0` success · `1` sync error or failures · `2` missing credentials
+
+Example success output:
+
+```json
+{
+  "ok": true,
+  "listed": 5,
+  "uploaded": 2,
+  "skipped": 3,
+  "failed": 0,
+  "downloaded": 2,
+  "activities": [
+    {
+      "ride_id": 123,
+      "title": "Morning ride",
+      "start_time": "2026-06-15 08:00:00"
+    }
+  ]
+}
+```
+
+Example credential error:
+
+```json
+{
+  "ok": false,
+  "error": "Missing required keys in ..."
+}
+```
+
+The agent should parse stdout JSON and check the exit code. It must **not**
+handle or write secrets.
+
+## Optional flags
+
+| Flag | Purpose |
+|------|---------|
+| `--env-file PATH` | Override secrets file location |
+| `--max-activities N` | Number of recent rides to process (default: 5) |
+| `--force-resync` | Re-upload even if already on intervals.icu |
+| `--activity-type TYPE` | Set intervals.icu sport after upload |
+| `--download-dir PATH` | Directory for temporary `.fit` files |
+| `--keep-files` | Do not delete `.fit` files after upload |
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `igpsync sync` | Full pipeline: list → download → upload to intervals.icu |
+| `igpsync check` | Validate `.env` exists and has all three required keys (no network) |
+
+## What it does
+
+Same as the GUI one-click sync:
+
+- Lists recent iGPSPORT activities
+- Skips rides already on intervals.icu (unless `--force-resync`)
+- Downloads `.fit` files and uploads to intervals.icu
+- Deletes local `.fit` files after successful upload (unless `--keep-files`)
+- Does **not** upload to Dropbox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "requests>=2.33.1",
 ]
 
+[project.scripts]
+igpsync = "igpsync.cli:main"
+
 [project.gui-scripts]
 igpsync-gui = "igpsync.gui.app:main"
 

--- a/src/igpsync/cli.py
+++ b/src/igpsync/cli.py
@@ -1,0 +1,236 @@
+"""Headless CLI for syncing iGPSPORT activities to intervals.icu.
+
+Designed for agent use (e.g. Hermes): credentials are read from the profile
+.env file; progress goes to stderr; structured results go to stdout with --json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import cli_config as cli_config_module
+from .cli_env import CliConfigError, load_credentials, resolve_env_path
+from .core import SyncConfig, SyncError, SyncResult, sync
+
+EXIT_OK = 0
+EXIT_SYNC_ERROR = 1
+EXIT_CONFIG_ERROR = 2
+
+
+def _build_sync_config(
+    credentials,
+    config: cli_config_module.CliConfig,
+    *,
+    max_activities: int | None,
+    force_resync: bool | None,
+    activity_type: str | None,
+    download_dir: str | None,
+    delete_after_upload: bool | None,
+) -> SyncConfig:
+    return SyncConfig(
+        igp_user=credentials.igp_user,
+        igp_password=credentials.igp_password,
+        intervals_api_key=credentials.intervals_api_key,
+        max_activities=max_activities if max_activities is not None else config.max_activities,
+        download_dir=Path(download_dir or config.download_dir),
+        delete_after_upload=(
+            delete_after_upload if delete_after_upload is not None else config.delete_after_upload
+        ),
+        force_resync=force_resync if force_resync is not None else config.force_resync,
+        activity_type=activity_type if activity_type is not None else config.activity_type,
+        list_activities=True,
+        get_download_url=True,
+        download_fit=True,
+        upload_intervals=True,
+        upload_dropbox=False,
+    )
+
+
+def _result_payload(result: SyncResult, *, ok: bool, error: str | None = None) -> dict:
+    payload = {
+        "ok": ok,
+        "listed": result.listed,
+        "uploaded": result.uploaded,
+        "skipped": result.skipped,
+        "failed": result.failed,
+        "downloaded": result.downloaded,
+        "activities": [
+            {
+                "ride_id": act.ride_id,
+                "title": act.title,
+                "start_time": act.start_time,
+            }
+            for act in result.activities
+        ],
+    }
+    if error is not None:
+        payload["error"] = error
+    return payload
+
+
+def _emit_json(payload: dict) -> None:
+    print(json.dumps(payload, indent=2))
+
+
+def _emit_text_summary(result: SyncResult) -> None:
+    print(
+        f"Done — uploaded {result.uploaded}, "
+        f"downloaded {result.downloaded}, "
+        f"skipped {result.skipped}, "
+        f"failed {result.failed}."
+    )
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    config = cli_config_module.load()
+    try:
+        env_path = resolve_env_path(
+            env_file=Path(args.env_file) if args.env_file else None,
+            config_env_file=config.env_file or None,
+        )
+        load_credentials(env_path)
+    except CliConfigError as exc:
+        if args.json:
+            _emit_json({"ok": False, "error": str(exc)})
+        else:
+            print(exc, file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    if args.json:
+        _emit_json({"ok": True, "env_file": str(env_path)})
+    else:
+        print(f"Credentials OK ({env_path})")
+    return EXIT_OK
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    config = cli_config_module.load()
+    use_json = args.json
+
+    try:
+        env_path = resolve_env_path(
+            env_file=Path(args.env_file) if args.env_file else None,
+            config_env_file=config.env_file or None,
+        )
+        credentials = load_credentials(env_path)
+    except CliConfigError as exc:
+        if use_json:
+            _emit_json({"ok": False, "error": str(exc)})
+        else:
+            print(exc, file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    delete_after_upload = False if args.keep_files else None
+
+    sync_config = _build_sync_config(
+        credentials,
+        config,
+        max_activities=args.max_activities,
+        force_resync=True if args.force_resync else None,
+        activity_type=args.activity_type,
+        download_dir=args.download_dir,
+        delete_after_upload=delete_after_upload,
+    )
+
+    def progress(message: str) -> None:
+        print(message, file=sys.stderr)
+
+    try:
+        result = sync(sync_config, progress=progress)
+    except SyncError as exc:
+        if use_json:
+            _emit_json(_result_payload(SyncResult(), ok=False, error=str(exc)))
+        else:
+            print(f"✗ {exc}", file=sys.stderr)
+        return EXIT_SYNC_ERROR
+    except Exception as exc:  # noqa: BLE001 — surface unexpected failures to agents
+        if use_json:
+            _emit_json(_result_payload(SyncResult(), ok=False, error=str(exc)))
+        else:
+            print(f"✗ Unexpected error: {exc}", file=sys.stderr)
+        return EXIT_SYNC_ERROR
+
+    ok = result.failed == 0
+    if use_json:
+        _emit_json(_result_payload(result, ok=ok))
+    else:
+        _emit_text_summary(result)
+
+    return EXIT_OK if ok else EXIT_SYNC_ERROR
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--env-file",
+        metavar="PATH",
+        help="Override path to the secrets .env file.",
+    )
+    common.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON on stdout (progress stays on stderr).",
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="igpsync",
+        description="Sync cycling activities from iGPSPORT to intervals.icu.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = True
+
+    check_parser = subparsers.add_parser(
+        "check",
+        parents=[common],
+        help="Validate credentials in the .env file (no network).",
+    )
+    check_parser.set_defaults(func=cmd_check)
+
+    sync_parser = subparsers.add_parser(
+        "sync",
+        parents=[common],
+        help="Download recent rides from iGPSPORT and upload to intervals.icu.",
+    )
+    sync_parser.add_argument(
+        "--max-activities",
+        type=int,
+        metavar="N",
+        help="Number of recent activities to process (default: from cli config).",
+    )
+    sync_parser.add_argument(
+        "--force-resync",
+        action="store_true",
+        help="Re-upload activities even if already on intervals.icu.",
+    )
+    sync_parser.add_argument(
+        "--activity-type",
+        metavar="TYPE",
+        help='intervals.icu sport to set after upload (e.g. "Mountain Bike Ride").',
+    )
+    sync_parser.add_argument(
+        "--download-dir",
+        metavar="PATH",
+        help="Directory for temporary .fit files.",
+    )
+    sync_parser.add_argument(
+        "--keep-files",
+        action="store_true",
+        help="Keep .fit files after upload instead of deleting them.",
+    )
+    sync_parser.set_defaults(func=cmd_sync)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    raise SystemExit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/igpsync/cli_config.py
+++ b/src/igpsync/cli_config.py
@@ -1,0 +1,47 @@
+"""Non-secret CLI settings persisted as JSON.
+
+Secrets never live here — they are read from the Hermes profile .env file via
+`cli_env.py`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from platformdirs import user_config_dir, user_downloads_dir
+
+APP_NAME = "igpsync-cli"
+
+CONFIG_DIR = Path(user_config_dir(APP_NAME, appauthor=False))
+CONFIG_PATH = CONFIG_DIR / "config.json"
+
+
+def _default_download_dir() -> str:
+    return str(Path(user_downloads_dir()) / "igpsport-fit")
+
+
+@dataclass
+class CliConfig:
+    # Optional override for the secrets .env file path.
+    env_file: str = ""
+    max_activities: int = 5
+    download_dir: str = field(default_factory=_default_download_dir)
+    delete_after_upload: bool = True
+    force_resync: bool = False
+    activity_type: str = ""
+
+
+def load() -> CliConfig:
+    """Load CLI config from disk, falling back to defaults."""
+    data: dict = {}
+    if CONFIG_PATH.exists():
+        data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    return CliConfig(**{k: v for k, v in data.items() if k in CliConfig.__annotations__})
+
+
+def save(config: CliConfig) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(asdict(config), indent=2), encoding="utf-8")

--- a/src/igpsync/cli_env.py
+++ b/src/igpsync/cli_env.py
@@ -1,0 +1,101 @@
+"""Credential loading for the headless CLI.
+
+Secrets are read from a .env file (Hermes profile or standalone). The CLI never
+writes secrets — users set them via their agent profile, e.g.:
+
+    {profile} config set IGPSYNC_IGP_USER you@example.com
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+IGP_USER_KEY = "IGPSYNC_IGP_USER"
+IGP_PASSWORD_KEY = "IGPSYNC_IGP_PASSWORD"
+INTERVALS_API_KEY_KEY = "IGPSYNC_INTERVALS_API_KEY"
+
+REQUIRED_KEYS = (IGP_USER_KEY, IGP_PASSWORD_KEY, INTERVALS_API_KEY_KEY)
+
+SETUP_HINT = (
+    "Ask the user to set credentials once (replace {profile} with their "
+    "Hermes profile name, or use 'hermes' for the default profile):\n"
+    f"  {{profile}} config set {IGP_USER_KEY} <email>\n"
+    f"  {{profile}} config set {IGP_PASSWORD_KEY} <password>\n"
+    f"  {{profile}} config set {INTERVALS_API_KEY_KEY} <api-key>"
+)
+
+
+class CliConfigError(Exception):
+    """Missing or invalid CLI credentials / env file."""
+
+
+@dataclass(frozen=True)
+class CliCredentials:
+    igp_user: str
+    igp_password: str
+    intervals_api_key: str
+
+
+def _default_hermes_env_path() -> Path:
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        return Path(hermes_home) / ".env"
+    return Path.home() / ".hermes" / ".env"
+
+
+def resolve_env_path(
+    *,
+    env_file: Path | None = None,
+    config_env_file: str | None = None,
+) -> Path:
+    """Resolve the secrets .env path (first match wins)."""
+    if env_file is not None:
+        return env_file.expanduser()
+    if config_env_file:
+        return Path(config_env_file).expanduser()
+    return _default_hermes_env_path()
+
+
+def parse_dotenv(text: str) -> dict[str, str]:
+    """Parse KEY=value lines from a .env file (stdlib only)."""
+    values: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def load_credentials(env_path: Path) -> CliCredentials:
+    """Load and validate the three required credentials from a .env file."""
+    if not env_path.is_file():
+        raise CliConfigError(
+            f"Secrets file not found: {env_path}\n{SETUP_HINT}"
+        )
+
+    values = parse_dotenv(env_path.read_text(encoding="utf-8"))
+    missing = [key for key in REQUIRED_KEYS if not values.get(key)]
+    if missing:
+        raise CliConfigError(
+            f"Missing required keys in {env_path}: {', '.join(missing)}\n{SETUP_HINT}"
+        )
+
+    return CliCredentials(
+        igp_user=values[IGP_USER_KEY],
+        igp_password=values[IGP_PASSWORD_KEY],
+        intervals_api_key=values[INTERVALS_API_KEY_KEY],
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,149 @@
+"""Tests for the headless CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from igpsync import cli, cli_config, cli_env, core
+
+
+def _write_env(path: Path, **overrides: str) -> None:
+    values = {
+        cli_env.IGP_USER_KEY: "user@example.com",
+        cli_env.IGP_PASSWORD_KEY: "secret",
+        cli_env.INTERVALS_API_KEY_KEY: "api-key-123",
+        **overrides,
+    }
+    lines = [f"{key}={value}" for key, value in values.items()]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_parse_dotenv_comments_and_quotes():
+    text = """
+# comment
+IGPSYNC_IGP_USER="quoted@example.com"
+export IGPSYNC_IGP_PASSWORD=pass
+IGPSYNC_INTERVALS_API_KEY=key
+"""
+    parsed = cli_env.parse_dotenv(text)
+    assert parsed["IGPSYNC_IGP_USER"] == "quoted@example.com"
+    assert parsed["IGPSYNC_IGP_PASSWORD"] == "pass"
+    assert parsed["IGPSYNC_INTERVALS_API_KEY"] == "key"
+
+
+def test_load_credentials_missing_keys(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("IGPSYNC_IGP_USER=only-user\n", encoding="utf-8")
+
+    with pytest.raises(cli_env.CliConfigError, match="IGPSYNC_IGP_PASSWORD"):
+        cli_env.load_credentials(env_file)
+
+
+def test_resolve_env_path_flag_wins(tmp_path: Path):
+    custom = tmp_path / "custom.env"
+    assert cli_env.resolve_env_path(env_file=custom) == custom
+
+
+def test_resolve_env_path_uses_config_env_file(tmp_path: Path, monkeypatch):
+    custom = tmp_path / "from-config.env"
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    assert cli_env.resolve_env_path(config_env_file=str(custom)) == custom
+
+
+def test_resolve_env_path_uses_hermes_home(tmp_path: Path, monkeypatch):
+    hermes_home = tmp_path / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    assert cli_env.resolve_env_path() == hermes_home / ".env"
+
+
+def test_resolve_env_path_default_hermes(monkeypatch):
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    assert cli_env.resolve_env_path() == Path.home() / ".hermes" / ".env"
+
+
+def test_check_ok(tmp_path: Path, capsys):
+    env_file = tmp_path / ".env"
+    _write_env(env_file)
+
+    args = cli._build_parser().parse_args(["check", "--env-file", str(env_file), "--json"])
+    assert cli.cmd_check(args) == cli.EXIT_OK
+
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert payload["env_file"] == str(env_file)
+
+
+def test_check_missing_credentials(tmp_path: Path, capsys):
+    env_file = tmp_path / ".env"
+    env_file.write_text("IGPSYNC_IGP_USER=incomplete\n", encoding="utf-8")
+
+    args = cli._build_parser().parse_args(["check", "--env-file", str(env_file), "--json"])
+    assert cli.cmd_check(args) == cli.EXIT_CONFIG_ERROR
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "IGPSYNC_IGP_PASSWORD" in payload["error"]
+
+
+def test_sync_json_success(tmp_path: Path, monkeypatch, capsys):
+    env_file = tmp_path / ".env"
+    _write_env(env_file)
+
+    activities = [core.Activity(1, "Ride", "2026-06-15 08:00:00")]
+
+    def fake_sync(config, progress=None):
+        if progress:
+            progress("working")
+        return core.SyncResult(
+            listed=1,
+            downloaded=1,
+            uploaded=1,
+            activities=activities,
+        )
+
+    monkeypatch.setattr(cli, "sync", fake_sync)
+
+    args = cli._build_parser().parse_args(
+        ["sync", "--env-file", str(env_file), "--json", "--download-dir", str(tmp_path / "dl")]
+    )
+    assert cli.cmd_sync(args) == cli.EXIT_OK
+
+    captured = capsys.readouterr()
+    assert "working" in captured.err
+    payload = json.loads(captured.out)
+    assert payload["ok"] is True
+    assert payload["uploaded"] == 1
+    assert payload["activities"][0]["ride_id"] == 1
+
+
+def test_sync_json_sync_error(tmp_path: Path, monkeypatch, capsys):
+    env_file = tmp_path / ".env"
+    _write_env(env_file)
+
+    def fake_sync(config, progress=None):
+        raise core.SyncError("login failed")
+
+    monkeypatch.setattr(cli, "sync", fake_sync)
+
+    args = cli._build_parser().parse_args(["sync", "--env-file", str(env_file), "--json"])
+    assert cli.cmd_sync(args) == cli.EXIT_SYNC_ERROR
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"] == "login failed"
+
+
+def test_cli_config_roundtrip(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(cli_config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cli_config, "CONFIG_PATH", tmp_path / "config.json")
+
+    cfg = cli_config.CliConfig(env_file="/custom/.env", max_activities=10)
+    cli_config.save(cfg)
+    loaded = cli_config.load()
+    assert loaded.env_file == "/custom/.env"
+    assert loaded.max_activities == 10


### PR DESCRIPTION
## Summary
- Add `igpsync` CLI (`sync` / `check`) that reuses `core.sync()` without touching the GUI or mobile builds
- Read credentials from the Hermes profile `.env` (auto-detected via `HERMES_HOME`; optional `--env-file` override)
- Ship `--json` output for agents and `docs/AGENT.md` with user setup via `{profile} config set`

## Test plan
- [x] `uv run pytest` (64 tests, all offline)
- [ ] `uv run igpsync check` with a test `.env` containing the three `IGPSYNC_*` keys
- [ ] `uv run igpsync sync --json` against real credentials (uploads to intervals.icu)
