### PR TITLE
docs(cli): require profile .env for all Hermes credentials

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -13,31 +13,60 @@ activities and only need a reliable upload trigger.
 
 ## User setup (human — not the agent)
 
-Agents cannot write secrets. The **user** must configure credentials once in
-their Hermes profile. Replace `{profile}` with the Hermes profile wrapper name
-(e.g. `hermes` for the default profile, or `coder` for a named profile):
+Agents cannot write secrets. The **user** must add all three credentials to a
+**`.env` file only** — never use `hermes config set` for the email or password.
+Hermes routes `config set` by key name: only names ending in `_API_KEY` /
+`_TOKEN` go to `.env`; everything else (including `IGPSYNC_IGP_USER` and
+`IGPSYNC_IGP_PASSWORD`) goes to **`config.yaml` in plaintext**, which we do not
+use.
+
+### Which `.env` file?
+
+Hermes sets `HERMES_HOME` in subprocesses to the **active profile** directory.
+The CLI reads `$HERMES_HOME/.env` automatically.
+
+| Profile | `.env` path | Auto-detected when |
+|---------|-------------|-------------------|
+| Default | `~/.hermes/.env` | `HERMES_HOME` unset |
+| Named (e.g. `coach`) | `~/.hermes/profiles/coach/.env` | agent runs under `coach` |
+
+So for a named profile, put secrets in **that profile's** `.env`, not the
+global `~/.hermes/.env` — otherwise `igpsync` won't find them.
+
+### Setup commands
+
+Replace paths and values. Example for the `coach` profile:
 
 ```bash
-{profile} config set IGPSYNC_IGP_USER you@example.com
-{profile} config set IGPSYNC_IGP_PASSWORD your-igpsport-password
-{profile} config set IGPSYNC_INTERVALS_API_KEY your-intervals-api-key
+PROFILE_HOME=/root/.hermes/profiles/coach
+
+echo 'IGPSYNC_IGP_USER=you@example.com' >> "$PROFILE_HOME/.env"
+echo 'IGPSYNC_IGP_PASSWORD=your-igpsport-password' >> "$PROFILE_HOME/.env"
+echo 'IGPSYNC_INTERVALS_API_KEY=your-intervals-api-key' >> "$PROFILE_HOME/.env"
+chmod 600 "$PROFILE_HOME/.env"
 ```
 
-Hermes stores these in `{HERMES_HOME}/.env`. The CLI reads that file
-automatically when run under Hermes (via the `HERMES_HOME` environment
-variable). No skill or `env_passthrough` configuration is required.
+Default profile (`hermes` with no named wrapper):
+
+```bash
+echo 'IGPSYNC_IGP_USER=you@example.com' >> ~/.hermes/.env
+echo 'IGPSYNC_IGP_PASSWORD=your-igpsport-password' >> ~/.hermes/.env
+echo 'IGPSYNC_INTERVALS_API_KEY=your-intervals-api-key' >> ~/.hermes/.env
+chmod 600 ~/.hermes/.env
+```
 
 **intervals.icu API key:** intervals.icu → Settings → Developer.
 
-Verify setup:
+If you previously ran `config set` for the user or password, remove those keys
+from `config.yaml` — they belong only in `.env`.
+
+Verify setup (from the repo, under the same profile the agent uses):
 
 ```bash
 uv run igpsync check
 ```
 
-Optional: override the secrets file path in CLI config
-(`platformdirs.user_config_dir("igpsync-cli")/config.json`) with an `env_file`
-field, or pass `--env-file PATH` per invocation.
+Optional: pass `--env-file /path/to/.env` to override auto-detection.
 
 ## Agent invocation
 

--- a/src/igpsync/cli_env.py
+++ b/src/igpsync/cli_env.py
@@ -1,9 +1,8 @@
 """Credential loading for the headless CLI.
 
-Secrets are read from a .env file (Hermes profile or standalone). The CLI never
-writes secrets — users set them via their agent profile, e.g.:
-
-    {profile} config set IGPSYNC_IGP_USER you@example.com
+All three credentials must live in a `.env` file. Do not use `hermes config set`
+for the email or password — Hermes routes those to `config.yaml` in plaintext.
+Append them to the profile `.env` instead (see docs/AGENT.md).
 """
 
 from __future__ import annotations
@@ -19,11 +18,12 @@ INTERVALS_API_KEY_KEY = "IGPSYNC_INTERVALS_API_KEY"
 REQUIRED_KEYS = (IGP_USER_KEY, IGP_PASSWORD_KEY, INTERVALS_API_KEY_KEY)
 
 SETUP_HINT = (
-    "Ask the user to set credentials once (replace {profile} with their "
-    "Hermes profile name, or use 'hermes' for the default profile):\n"
-    f"  {{profile}} config set {IGP_USER_KEY} <email>\n"
-    f"  {{profile}} config set {IGP_PASSWORD_KEY} <password>\n"
-    f"  {{profile}} config set {INTERVALS_API_KEY_KEY} <api-key>"
+    "Ask the user to append all three keys to their Hermes profile .env "
+    "(replace {profile_home} with the profile directory, e.g. "
+    "~/.hermes/profiles/coach):\n"
+    f"  echo '{IGP_USER_KEY}=<email>' >> {{profile_home}}/.env\n"
+    f"  echo '{IGP_PASSWORD_KEY}=<password>' >> {{profile_home}}/.env\n"
+    f"  echo '{INTERVALS_API_KEY_KEY}=<api-key>' >> {{profile_home}}/.env"
 )
 
 


### PR DESCRIPTION
## Summary
- Document Hermes credential setup via `echo >>` to the profile `.env` (not `config set`, which puts user/password in `config.yaml` plaintext)
- Clarify which `.env` path is used per profile (`$HERMES_HOME/.env`)
- Update CLI setup hints to match

## Test plan
- [x] `uv run pytest tests/test_cli.py`
