### PR TITLE
feat(sync): add workout upload to iGPSPORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # iGPSPORT → intervals.icu
 
-A small, friendly app that syncs your cycling activities from **iGPSPORT** to
+A small, friendly app that syncs your cycling activities between **iGPSPORT** and
 **intervals.icu**. It's built for non-technical riders — no command line, no config
 files: enter your credentials once, press **Sync**, and your latest rides land on
-intervals.icu. Free and open source, for **Windows** and **Android**.
+intervals.icu. You can also push planned workouts the other way. Free and open
+source, for **Windows** and **Android**.
 
 ## Features
 
 - Lists your recent iGPSPORT activities and uploads the original `.fit` files to intervals.icu
+- **Upload workouts** — push planned cycling workouts from your intervals.icu calendar to iGPSPORT custom workouts (sync to your head unit from the iGPSPORT app)
 - **Skips activities already uploaded** so re-running is safe — with an optional *force re-sync*
 - Lets you choose how many recent activities to process
+- **Workout upload window** in Settings — how many calendar days to upload (default: today only)
 - **Sets the intervals.icu sport type** after upload (e.g. Mountain Bike Ride / Gravel Ride) — iGPSPORT exports everything as a generic "Ride"
 - Optionally deletes the local `.fit` files after a successful upload
 - Stores your credentials in the **OS secure vault** (Windows Credential Manager / Android Keystore), never in a file
@@ -24,7 +27,7 @@ intervals.icu. Free and open source, for **Windows** and **Android**.
 3. On first launch, open **Settings** and enter:
    - your iGPSPORT **email** and **password**
    - your intervals.icu **API key** (intervals.icu → Settings → Developer)
-4. Click **Save**, then go back and press **Sync activities**.
+4. Click **Save**, then go back and press **Sync activities** (or **Upload workouts** for planned sessions on your intervals.icu calendar).
 
 Your password and API key are stored in your operating system's **secure
 credential store** — Windows Credential Manager on Windows (the same vault
@@ -35,7 +38,7 @@ Windows uses for its own logins) — never in a plain text file.
 1. On the [Releases](../../releases) page, download the latest `.apk`.
 2. Open it on your phone. Android will ask you to allow installing from this
    source — accept (Settings → "Install unknown apps" for your browser/files app).
-3. Open the app, fill in **Settings** (same fields as above), and **Sync**.
+3. Open the app, fill in **Settings** (same fields as above), then **Sync activities** or **Upload workouts**.
 
 On Android your credentials are stored in the **Android Keystore**. The app
 isn't on the Play Store, so the "unknown source" prompt is expected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ license-files = ["LICENSE"]
 requires-python = ">=3.13"
 dependencies = [
     "dropbox>=12.0.2",
-    "flet>=0.28",
-    "flet-permission-handler>=0.85.2",
-    "flet-secure-storage>=0.85.2",
+    "flet>=0.85.3",
+    "flet-permission-handler>=0.85.3",
+    "flet-secure-storage>=0.85.3",
     "packaging>=26.2",
     "platformdirs>=4.0",
     "requests>=2.33.1",

--- a/src/igpsync/config.py
+++ b/src/igpsync/config.py
@@ -47,6 +47,10 @@ class AppConfig:
     upload_dropbox: bool = False
     dropbox_folder: str = "/igpsport-fit"
     dropbox_date_filenames: bool = True
+    # Planned workouts: intervals.icu event id → iGPSPORT workoutId.
+    uploaded_workouts: dict[str, int] = field(default_factory=dict)
+    # How many calendar days of planned workouts to upload (1 = today only).
+    workout_days_ahead: int = 1
 
 
 def load() -> AppConfig:

--- a/src/igpsync/gui/settings_view.py
+++ b/src/igpsync/gui/settings_view.py
@@ -65,6 +65,15 @@ async def build_settings_view(
         width=220,
     )
 
+    workout_days_ahead = ft.TextField(
+        label="Workout upload window (days)",
+        value=str(config.workout_days_ahead),
+        prefix_icon=ft.Icons.CALENDAR_MONTH,
+        keyboard_type=ft.KeyboardType.NUMBER,
+        width=220,
+        helper="Planned workouts from intervals.icu; 1 = today only",
+    )
+
     activity_type = ft.Dropdown(
         label="Activity type on intervals.icu",
         value=config.activity_type,
@@ -331,6 +340,11 @@ async def build_settings_view(
         except (TypeError, ValueError):
             config.max_activities = 5
             max_activities.value = "5"
+        try:
+            config.workout_days_ahead = max(1, int(workout_days_ahead.value))
+        except (TypeError, ValueError):
+            config.workout_days_ahead = 1
+            workout_days_ahead.value = "1"
         config.delete_after_upload = delete_after_upload.value
         config.force_resync = force_resync.value
         config.activity_type = activity_type.value or ""
@@ -397,6 +411,7 @@ async def build_settings_view(
                     igp_password,
                     api_key,
                     max_activities,
+                    workout_days_ahead,
                     activity_type,
                     delete_after_upload,
                     force_resync,

--- a/src/igpsync/gui/sync_view.py
+++ b/src/igpsync/gui/sync_view.py
@@ -8,6 +8,7 @@ from .. import config as config_module
 from .. import secrets as secrets_module
 from ..core import SyncConfig, SyncError, sync
 from ..dropbox_client import get_dropbox_app_key
+from ..workout import WorkoutUploadConfig, upload_workouts
 
 
 def build_sync_view(
@@ -23,6 +24,15 @@ def build_sync_view(
         icon=ft.Icons.SYNC,
         height=52,
     )
+    upload_workouts_button = ft.OutlinedButton(
+        "Upload workouts",
+        icon=ft.Icons.FITNESS_CENTER,
+        height=52,
+    )
+
+    def set_buttons_enabled(enabled: bool) -> None:
+        sync_button.disabled = not enabled
+        upload_workouts_button.disabled = not enabled
 
     def append_log(message: str) -> None:
         log.controls.append(ft.Text(message, size=13, selectable=True))
@@ -73,7 +83,36 @@ def build_sync_view(
             append_log(f"✗ Unexpected error: {exc}")
         finally:
             progress.visible = False
-            sync_button.disabled = False
+            set_buttons_enabled(True)
+            page.update()
+
+    def run_upload_workouts(igp_password: str, api_key: str) -> None:
+        upload_config = WorkoutUploadConfig(
+            igp_user=config.igp_user,
+            igp_password=igp_password,
+            intervals_api_key=api_key,
+            workout_days_ahead=config.workout_days_ahead,
+            uploaded_workouts=dict(config.uploaded_workouts),
+            force_resync=config.force_resync,
+        )
+
+        try:
+            result = upload_workouts(upload_config, progress=append_log)
+            if result.uploaded_map:
+                config.uploaded_workouts.update(result.uploaded_map)
+                config_module.save(config)
+            append_log(
+                f"\nDone — uploaded {result.uploaded}, "
+                f"skipped {result.skipped}, no steps {result.no_steps}, "
+                f"failed {result.failed}."
+            )
+        except SyncError as exc:
+            append_log(f"✗ {exc}")
+        except Exception as exc:  # noqa: BLE001 — surface any failure to the user
+            append_log(f"✗ Unexpected error: {exc}")
+        finally:
+            progress.visible = False
+            set_buttons_enabled(True)
             page.update()
 
     async def on_sync_click(_: ft.ControlEvent) -> None:
@@ -87,10 +126,8 @@ def build_sync_view(
 
         log.controls.clear()
         progress.visible = True
-        sync_button.disabled = True
+        set_buttons_enabled(False)
         page.update()
-        # Run off the UI thread (via Flet's managed executor) so the window
-        # stays responsive and per-step updates flush to the client live.
         page.run_thread(
             run_sync,
             igp_password,
@@ -99,18 +136,40 @@ def build_sync_view(
             dropbox_app_key,
         )
 
+    async def on_upload_workouts_click(_: ft.ControlEvent) -> None:
+        igp_password = await store.get(secrets_module.IGP_PASSWORD)
+        if not config.igp_user or not igp_password:
+            page.show_dialog(ft.SnackBar(ft.Text("Add your credentials in Settings first.")))
+            return
+        api_key = await store.get(secrets_module.INTERVALS_API_KEY)
+        if not api_key:
+            page.show_dialog(
+                ft.SnackBar(ft.Text("Add your intervals.icu API key in Settings first."))
+            )
+            return
+
+        log.controls.clear()
+        progress.visible = True
+        set_buttons_enabled(False)
+        page.update()
+        page.run_thread(run_upload_workouts, igp_password, api_key)
+
     sync_button.on_click = on_sync_click
+    upload_workouts_button.on_click = on_upload_workouts_click
 
     return ft.Column(
         spacing=16,
         controls=[
             ft.Text(
-                "Download your latest rides from iGPSPORT and upload them to "
-                "intervals.icu.",
+                "Sync rides from iGPSPORT to intervals.icu, or upload planned "
+                "workouts from intervals.icu to iGPSPORT.",
                 size=14,
                 color=ft.Colors.ON_SURFACE_VARIANT,
             ),
-            sync_button,
+            ft.Row(
+                controls=[sync_button, upload_workouts_button],
+                spacing=12,
+            ),
             progress,
             ft.Card(
                 content=ft.Container(

--- a/src/igpsync/workout.py
+++ b/src/igpsync/workout.py
@@ -1,0 +1,474 @@
+"""Upload planned workouts from intervals.icu to iGPSPORT custom workouts.
+
+Uses the mobile JSON API (EditCustomWorkOut), not FIT upload. Source data is
+intervals.icu ``workout_doc`` from calendar events (see intervals.icu forum
+guide on downloading planned workouts).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any, Callable
+
+import requests
+
+from .core import SyncError, login
+
+IGPS_API = "https://prod.en.igpsport.com"
+IGPS_WORKOUT_LIST_URL = f"{IGPS_API}/service/mobile/api/WorkOut/CustomWorkout"
+IGPS_WORKOUT_EDIT_URL = f"{IGPS_API}/service/mobile/api/WorkOut/EditCustomWorkOut"
+INTERVALS_EVENTS_URL = "https://intervals.icu/api/v1/athlete/0/events"
+
+# intervals.icu cycling types we accept in v1.
+_CYCLING_TYPES = frozenset(
+    {
+        "Ride",
+        "MountainBikeRide",
+        "GravelRide",
+        "VirtualRide",
+        "EBikeRide",
+        "EMountainBikeRide",
+        "TrackRide",
+        "Cyclocross",
+        "Handcycle",
+        "Velomobile",
+    }
+)
+
+Progress = Callable[[str], None]
+
+
+def _noop(_message: str) -> None:
+    pass
+
+
+@dataclass
+class CalendarWorkout:
+    event_id: int
+    name: str
+    description: str
+    activity_type: str
+    workout_doc: dict[str, Any]
+
+
+@dataclass
+class WorkoutUploadResult:
+    listed: int = 0
+    uploaded: int = 0
+    skipped: int = 0
+    failed: int = 0
+    no_steps: int = 0
+    uploaded_map: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class WorkoutUploadConfig:
+    igp_user: str
+    igp_password: str
+    intervals_api_key: str
+    oldest: date | None = None
+    newest: date | None = None
+    workout_days_ahead: int = 1
+    uploaded_workouts: dict[str, int] = field(default_factory=dict)
+    force_resync: bool = False
+
+
+def list_custom_workouts(
+    session: requests.Session,
+    auth_headers: dict[str, str],
+    page_index: int = 1,
+    page_size: int = 20,
+) -> dict[str, Any]:
+    """Return the iGPSPORT custom-workout list response JSON."""
+    resp = session.get(
+        IGPS_WORKOUT_LIST_URL,
+        params={"PageIndex": page_index, "PageSize": page_size},
+        headers=auth_headers,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def upload_custom_workout(
+    session: requests.Session,
+    auth_headers: dict[str, str],
+    body: dict[str, Any],
+) -> int | None:
+    """Create or update a custom workout; return workoutId on success."""
+    resp = session.post(IGPS_WORKOUT_EDIT_URL, json=body, headers=auth_headers)
+    if not resp.ok:
+        return None
+    data = resp.json()
+    if data.get("code") != 0:
+        return None
+    payload = data.get("data") or {}
+    workout_id = payload.get("workoutId")
+    return int(workout_id) if workout_id is not None else None
+
+
+def fetch_calendar_workouts(
+    api_key: str,
+    oldest: date,
+    newest: date,
+) -> list[CalendarWorkout]:
+    """Fetch planned workouts from the intervals.icu calendar."""
+    resp = requests.get(
+        INTERVALS_EVENTS_URL,
+        params={
+            "category": "WORKOUT",
+            "resolve": "true",
+            "oldest": oldest.isoformat(),
+            "newest": newest.isoformat(),
+        },
+        auth=("API_KEY", api_key),
+    )
+    resp.raise_for_status()
+    workouts: list[CalendarWorkout] = []
+    for event in resp.json():
+        if event.get("category") != "WORKOUT":
+            continue
+        workout_doc = event.get("workout_doc")
+        if not isinstance(workout_doc, dict):
+            continue
+        workouts.append(
+            CalendarWorkout(
+                event_id=int(event["id"]),
+                name=str(event.get("name") or "Workout"),
+                description=str(event.get("description") or ""),
+                activity_type=str(event.get("type") or "Ride"),
+                workout_doc=workout_doc,
+            )
+        )
+    return workouts
+
+
+def _step_name(step: dict[str, Any], index: int) -> str:
+    text = str(step.get("text") or "").strip()
+    if text:
+        return text[:64]
+    return f"Step {index}"
+
+
+def _intensity_class(step: dict[str, Any]) -> str:
+    intensity = str(step.get("intensity") or "").lower()
+    if step.get("warmup") or intensity == "warmup":
+        return "WarmUp"
+    if step.get("cooldown") or intensity == "cooldown":
+        return "CoolDown"
+    if intensity in ("rest", "recovery"):
+        return "Rest"
+    return "Active"
+
+
+def _num(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _map_power_target(step: dict[str, Any]) -> dict[str, Any] | None:
+    resolved = step.get("_power")
+    if isinstance(resolved, dict):
+        start = _num(resolved.get("start"))
+        end = _num(resolved.get("end"))
+        value = _num(resolved.get("value"))
+        min_v = start if start is not None else value
+        max_v = end if end is not None else value
+        if min_v is None and max_v is None:
+            return None
+        min_v = int(min_v if min_v is not None else max_v)
+        max_v = int(max_v if max_v is not None else min_v)
+        if min_v > max_v:
+            min_v, max_v = max_v, min_v
+        return {
+            "unit": "PowerCustom",
+            "value": 0,
+            "minValue": min_v,
+            "maxValue": max_v,
+        }
+
+    power = step.get("power")
+    if not isinstance(power, dict):
+        return None
+
+    units = str(power.get("units") or "").lower()
+    start = _num(power.get("start"))
+    end = _num(power.get("end"))
+    value = _num(power.get("value"))
+    min_v = start if start is not None else value
+    max_v = end if end is not None else value
+    if min_v is None and max_v is None:
+        return None
+    min_v = int(min_v if min_v is not None else max_v)
+    max_v = int(max_v if max_v is not None else min_v)
+    if min_v > max_v:
+        min_v, max_v = max_v, min_v
+
+    if units == "%ftp":
+        return {
+            "unit": "PercentOfFTP",
+            "minValue": min_v,
+            "maxValue": max_v,
+        }
+    return {
+        "unit": "PowerCustom",
+        "value": 0,
+        "minValue": min_v,
+        "maxValue": max_v,
+    }
+
+
+def _map_hr_target(step: dict[str, Any]) -> dict[str, Any] | None:
+    resolved = step.get("_hr")
+    if isinstance(resolved, dict):
+        start = _num(resolved.get("start"))
+        end = _num(resolved.get("end"))
+        value = _num(resolved.get("value"))
+        min_v = start if start is not None else value
+        max_v = end if end is not None else value
+        if min_v is not None and max_v is not None:
+            return {
+                "unit": "HeartRateCustom",
+                "minValue": int(min_v),
+                "maxValue": int(max_v),
+            }
+        if value is not None:
+            if 1 <= value <= 5 and value == int(value):
+                return {"unit": "HeartRate", "value": int(value)}
+            return {
+                "unit": "HeartRateCustom",
+                "minValue": int(value),
+                "maxValue": int(value),
+            }
+
+    hr = step.get("hr")
+    if not isinstance(hr, dict):
+        return None
+    value = _num(hr.get("value"))
+    start = _num(hr.get("start"))
+    end = _num(hr.get("end"))
+    if start is not None and end is not None:
+        return {
+            "unit": "HeartRateCustom",
+            "minValue": int(start),
+            "maxValue": int(end),
+        }
+    if value is not None:
+        if 1 <= value <= 5 and value == int(value):
+            return {"unit": "HeartRate", "value": int(value)}
+        return {
+            "unit": "HeartRateCustom",
+            "minValue": int(value),
+            "maxValue": int(value),
+        }
+    return None
+
+
+def _map_cadence_target(step: dict[str, Any]) -> dict[str, Any] | None:
+    cadence = step.get("cadence")
+    if not isinstance(cadence, dict):
+        return None
+    value = _num(cadence.get("value"))
+    start = _num(cadence.get("start"))
+    end = _num(cadence.get("end"))
+    min_v = start if start is not None else value
+    max_v = end if end is not None else value
+    if min_v is None and max_v is None:
+        return None
+    min_v = int(min_v if min_v is not None else max_v)
+    max_v = int(max_v if max_v is not None else min_v)
+    return {"unit": "Cadence", "minValue": min_v, "maxValue": max_v}
+
+
+def _map_icu_step(step: dict[str, Any], index: int) -> dict[str, Any] | None:
+    reps = step.get("reps")
+    nested = step.get("steps")
+    if reps and isinstance(nested, list) and nested:
+        child_steps = []
+        for i, child in enumerate(nested, start=1):
+            if not isinstance(child, dict):
+                continue
+            mapped = _map_icu_step(child, i)
+            if mapped is not None:
+                child_steps.append(mapped)
+        if not child_steps:
+            return None
+        return {
+            "type": "Repetition",
+            "name": _step_name(step, index),
+            "uuid": str(uuid.uuid4()),
+            "intensityClass": "Active",
+            "openDuration": "false",
+            "length": {"unit": "Repetition", "value": int(reps)},
+            "steps": child_steps,
+        }
+
+    open_duration = bool(step.get("until_lap_press"))
+    igp_step: dict[str, Any] = {
+        "type": "Step",
+        "name": _step_name(step, index),
+        "uuid": str(uuid.uuid4()),
+        "intensityClass": _intensity_class(step),
+        "openDuration": "true" if open_duration else "false",
+    }
+
+    if not open_duration:
+        duration = step.get("duration")
+        if duration is None:
+            return None
+        igp_step["length"] = {"unit": "Second", "value": int(duration)}
+
+    power_target = _map_power_target(step)
+    if power_target:
+        igp_step["intensityTarget"] = power_target
+    else:
+        hr_target = _map_hr_target(step)
+        if hr_target:
+            igp_step["intensityTarget"] = hr_target
+
+    cadence_target = _map_cadence_target(step)
+    if cadence_target:
+        igp_step["cadenceTarget"] = cadence_target
+
+    return igp_step
+
+
+def _total_time(structure: list[dict[str, Any]], workout_doc: dict[str, Any]) -> int:
+    doc_duration = workout_doc.get("duration")
+    if isinstance(doc_duration, int) and doc_duration > 0:
+        return doc_duration
+    if isinstance(doc_duration, float) and doc_duration > 0:
+        return int(doc_duration)
+
+    total = 0
+
+    def walk(steps: list[dict[str, Any]], repeat: int = 1) -> None:
+        nonlocal total
+        for step in steps:
+            if step.get("type") == "Repetition":
+                reps = step.get("length", {}).get("value", 1)
+                nested = step.get("steps") or []
+                walk(nested, repeat * int(reps))
+            elif step.get("openDuration") != "true":
+                length = step.get("length") or {}
+                if length.get("unit") == "Second":
+                    total += int(length.get("value", 0)) * repeat
+
+    walk(structure)
+    return total
+
+
+def icu_workout_doc_to_igps(
+    name: str,
+    description: str,
+    workout_doc: dict[str, Any],
+    *,
+    existing_workout_id: int | None = None,
+) -> dict[str, Any] | None:
+    """Map intervals.icu workout_doc to an EditCustomWorkOut request body."""
+    raw_steps = workout_doc.get("steps")
+    if not isinstance(raw_steps, list) or not raw_steps:
+        return None
+
+    structure: list[dict[str, Any]] = []
+    for i, step in enumerate(raw_steps, start=1):
+        if not isinstance(step, dict):
+            continue
+        mapped = _map_icu_step(step, i)
+        if mapped is not None:
+            structure.append(mapped)
+
+    if not structure:
+        return None
+
+    doc_description = str(workout_doc.get("description") or description or "")
+    data: dict[str, Any] = {
+        "title": name[:64],
+        "description": doc_description[:500],
+        "totalTime": _total_time(structure, workout_doc),
+        "workoutType": "bike",
+        "sportBigType": 1,
+        "allowDeletion": True,
+        "structure": structure,
+    }
+    if existing_workout_id:
+        data["id"] = str(existing_workout_id)
+
+    return {"data": data}
+
+
+def upload_workouts(
+    config: WorkoutUploadConfig,
+    progress: Progress | None = None,
+) -> WorkoutUploadResult:
+    """Fetch upcoming intervals.icu workouts and push them to iGPSPORT."""
+    report = progress or _noop
+    result = WorkoutUploadResult()
+
+    today = date.today()
+    oldest = config.oldest or today
+    days = max(1, config.workout_days_ahead)
+    newest = config.newest or (today + timedelta(days=days - 1))
+
+    report("Logging in to iGPSPORT…")
+    session = requests.Session()
+    auth_headers = login(session, config.igp_user, config.igp_password)
+    report("Logged in.")
+
+    report("Fetching planned workouts from intervals.icu…")
+    try:
+        calendar = fetch_calendar_workouts(config.intervals_api_key, oldest, newest)
+    except requests.RequestException as exc:
+        raise SyncError(f"Could not fetch intervals.icu workouts: {exc}") from exc
+
+    result.listed = len(calendar)
+    report(f"Found {len(calendar)} planned workouts.")
+
+    for workout in calendar:
+        event_key = str(workout.event_id)
+
+        if workout.activity_type not in _CYCLING_TYPES:
+            report(
+                f"↷ Skipping {workout.name} — unsupported type "
+                f"{workout.activity_type!r} (cycling only in v1)."
+            )
+            result.skipped += 1
+            continue
+
+        existing_id = config.uploaded_workouts.get(event_key)
+        if existing_id and not config.force_resync:
+            report(f"↷ Skipping {workout.name} — already on iGPSPORT.")
+            result.skipped += 1
+            continue
+
+        update_id = existing_id if config.force_resync and existing_id else None
+        body = icu_workout_doc_to_igps(
+            workout.name,
+            workout.description,
+            workout.workout_doc,
+            existing_workout_id=update_id,
+        )
+        if body is None:
+            report(
+                f"⚠ Skipping {workout.name} — no structured steps "
+                "(open the workout in intervals.icu first)."
+            )
+            result.no_steps += 1
+            continue
+
+        report(f"Uploading {workout.name}…")
+        workout_id = upload_custom_workout(session, auth_headers, body)
+        if workout_id:
+            report(f"✓ Uploaded {workout.name} (workoutId {workout_id})")
+            result.uploaded += 1
+            result.uploaded_map[event_key] = workout_id
+        else:
+            report(f"✗ Failed to upload {workout.name}.")
+            result.failed += 1
+
+    return result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,8 @@ def test_defaults():
     assert cfg.upload_dropbox is False
     assert cfg.dropbox_folder == "/igpsport-fit"
     assert cfg.dropbox_date_filenames is True
+    assert cfg.uploaded_workouts == {}
+    assert cfg.workout_days_ahead == 1
 
 
 def test_save_and_load_roundtrip(tmp_path, monkeypatch):

--- a/tests/test_workout.py
+++ b/tests/test_workout.py
@@ -1,0 +1,301 @@
+"""Tests for intervals.icu → iGPSPORT workout upload."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from igpsync import workout
+
+
+class FakeResponse:
+    def __init__(self, *, status=200, json_data=None):
+        self.status_code = status
+        self.ok = 200 <= status < 300
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise workout.requests.HTTPError(f"HTTP {self.status_code}")
+
+
+def test_icu_workout_doc_maps_simple_ftp_step():
+    doc = {
+        "duration": 3600,
+        "steps": [
+            {
+                "duration": 3600,
+                "power": {"value": 100, "units": "%ftp"},
+            }
+        ],
+    }
+    body = workout.icu_workout_doc_to_igps("FTP Test", "desc", doc)
+    assert body is not None
+    data = body["data"]
+    assert data["title"] == "FTP Test"
+    assert data["workoutType"] == "bike"
+    assert data["sportBigType"] == 1
+    assert data["totalTime"] == 3600
+    step = data["structure"][0]
+    assert step["type"] == "Step"
+    assert step["length"] == {"unit": "Second", "value": 3600}
+    assert step["intensityTarget"] == {
+        "unit": "PercentOfFTP",
+        "minValue": 100,
+        "maxValue": 100,
+    }
+
+
+def test_icu_workout_doc_prefers_resolved_power_watts():
+    doc = {
+        "steps": [
+            {
+                "duration": 600,
+                "warmup": True,
+                "ramp": True,
+                "power": {"start": 35, "end": 55, "units": "%ftp"},
+                "_power": {"start": 98, "end": 154},
+            }
+        ],
+    }
+    body = workout.icu_workout_doc_to_igps("Warmup", "", doc)
+    assert body is not None
+    step = body["data"]["structure"][0]
+    assert step["intensityClass"] == "WarmUp"
+    assert step["intensityTarget"] == {
+        "unit": "PowerCustom",
+        "value": 0,
+        "minValue": 98,
+        "maxValue": 154,
+    }
+
+
+def test_icu_workout_doc_maps_repetition_block():
+    doc = {
+        "steps": [
+            {
+                "reps": 4,
+                "steps": [
+                    {"duration": 300, "power": {"value": 110, "units": "%ftp"}},
+                    {"duration": 90, "power": {"value": 55, "units": "%ftp"}},
+                ],
+            }
+        ],
+    }
+    body = workout.icu_workout_doc_to_igps("Intervals", "", doc)
+    assert body is not None
+    rep = body["data"]["structure"][0]
+    assert rep["type"] == "Repetition"
+    assert rep["length"] == {"unit": "Repetition", "value": 4}
+    assert len(rep["steps"]) == 2
+
+
+def test_icu_workout_doc_open_duration_step():
+    doc = {
+        "steps": [
+            {
+                "until_lap_press": True,
+                "intensity": "rest",
+            }
+        ],
+    }
+    body = workout.icu_workout_doc_to_igps("Open", "", doc)
+    assert body is not None
+    step = body["data"]["structure"][0]
+    assert step["openDuration"] == "true"
+    assert step["intensityClass"] == "Rest"
+    assert "length" not in step
+
+
+def test_icu_workout_doc_returns_none_without_steps():
+    assert workout.icu_workout_doc_to_igps("Empty", "", {}) is None
+    assert workout.icu_workout_doc_to_igps("Empty", "", {"steps": []}) is None
+
+
+def test_icu_workout_doc_includes_existing_id_for_update():
+    doc = {"steps": [{"duration": 60}]}
+    body = workout.icu_workout_doc_to_igps("Update", "", doc, existing_workout_id=5012)
+    assert body is not None
+    assert body["data"]["id"] == "5012"
+
+
+def test_fetch_calendar_workouts(monkeypatch):
+    monkeypatch.setattr(
+        workout.requests,
+        "get",
+        lambda *a, **k: FakeResponse(
+            json_data=[
+                {
+                    "id": 100,
+                    "category": "WORKOUT",
+                    "name": "Big Gear",
+                    "description": "Strength",
+                    "type": "Ride",
+                    "workout_doc": {"steps": [{"duration": 120}]},
+                },
+                {
+                    "id": 101,
+                    "category": "NOTE",
+                    "name": "Rest day",
+                },
+            ]
+        ),
+    )
+    items = workout.fetch_calendar_workouts("key", date(2026, 6, 1), date(2026, 6, 14))
+    assert len(items) == 1
+    assert items[0].event_id == 100
+    assert items[0].name == "Big Gear"
+
+
+def test_upload_custom_workout_returns_id(monkeypatch):
+    monkeypatch.setattr(
+        workout.requests.Session,
+        "post",
+        lambda self, *a, **k: FakeResponse(json_data={"code": 0, "data": {"workoutId": 999}}),
+    )
+    session = workout.requests.Session()
+    wid = workout.upload_custom_workout(session, {"Authorization": "Bearer x"}, {"data": {}})
+    assert wid == 999
+
+
+def test_upload_custom_workout_returns_none_on_error(monkeypatch):
+    monkeypatch.setattr(
+        workout.requests.Session,
+        "post",
+        lambda self, *a, **k: FakeResponse(status=400, json_data={"code": 1}),
+    )
+    session = workout.requests.Session()
+    assert workout.upload_custom_workout(session, {}, {}) is None
+
+
+def test_list_custom_workouts(monkeypatch):
+    captured: dict = {}
+
+    def fake_get(self, url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params")
+        return FakeResponse(json_data={"code": 0, "data": {"items": []}})
+
+    monkeypatch.setattr(workout.requests.Session, "get", fake_get)
+    session = workout.requests.Session()
+    workout.list_custom_workouts(session, {"Authorization": "Bearer t"}, page_index=2, page_size=5)
+    assert captured["url"] == workout.IGPS_WORKOUT_LIST_URL
+    assert captured["params"] == {"PageIndex": 2, "PageSize": 5}
+
+
+def test_upload_workouts_skips_already_uploaded(monkeypatch):
+    monkeypatch.setattr(workout, "login", lambda s, u, p: {"Authorization": "Bearer t"})
+    monkeypatch.setattr(
+        workout,
+        "fetch_calendar_workouts",
+        lambda *a, **k: [
+            workout.CalendarWorkout(
+                event_id=42,
+                name="Done",
+                description="",
+                activity_type="Ride",
+                workout_doc={"steps": [{"duration": 60}]},
+            )
+        ],
+    )
+    upload_calls: list = []
+    monkeypatch.setattr(
+        workout,
+        "upload_custom_workout",
+        lambda *a, **k: upload_calls.append(1) or 123,
+    )
+
+    cfg = workout.WorkoutUploadConfig(
+        igp_user="u",
+        igp_password="p",
+        intervals_api_key="k",
+        uploaded_workouts={"42": 100},
+    )
+    result = workout.upload_workouts(cfg)
+    assert result.skipped == 1
+    assert result.uploaded == 0
+    assert upload_calls == []
+
+
+def test_upload_workouts_uploads_new_workout(monkeypatch):
+    monkeypatch.setattr(workout, "login", lambda s, u, p: {"Authorization": "Bearer t"})
+    monkeypatch.setattr(
+        workout,
+        "fetch_calendar_workouts",
+        lambda *a, **k: [
+            workout.CalendarWorkout(
+                event_id=7,
+                name="New",
+                description="",
+                activity_type="Ride",
+                workout_doc={"steps": [{"duration": 120, "power": {"value": 90, "units": "%ftp"}}]},
+            )
+        ],
+    )
+    monkeypatch.setattr(workout, "upload_custom_workout", lambda *a, **k: 555)
+
+    cfg = workout.WorkoutUploadConfig(
+        igp_user="u",
+        igp_password="p",
+        intervals_api_key="k",
+    )
+    result = workout.upload_workouts(cfg)
+    assert result.uploaded == 1
+    assert result.uploaded_map == {"7": 555}
+
+
+def test_upload_workouts_skips_non_cycling_type(monkeypatch):
+    monkeypatch.setattr(workout, "login", lambda s, u, p: {"Authorization": "Bearer t"})
+    monkeypatch.setattr(
+        workout,
+        "fetch_calendar_workouts",
+        lambda *a, **k: [
+            workout.CalendarWorkout(
+                event_id=1,
+                name="Run",
+                description="",
+                activity_type="Run",
+                workout_doc={"steps": [{"duration": 60}]},
+            )
+        ],
+    )
+    result = workout.upload_workouts(
+        workout.WorkoutUploadConfig(igp_user="u", igp_password="p", intervals_api_key="k")
+    )
+    assert result.skipped == 1
+    assert result.uploaded == 0
+
+
+def test_upload_workouts_one_day_window_uses_today_only(monkeypatch):
+    captured: dict = {}
+    today = date(2026, 6, 17)
+
+    class FixedDate(date):
+        @classmethod
+        def today(cls):
+            return today
+
+    monkeypatch.setattr(workout, "date", FixedDate)
+    monkeypatch.setattr(workout, "login", lambda s, u, p: {"Authorization": "Bearer t"})
+
+    def fake_fetch(api_key, oldest, newest):
+        captured["oldest"] = oldest
+        captured["newest"] = newest
+        return []
+
+    monkeypatch.setattr(workout, "fetch_calendar_workouts", fake_fetch)
+
+    workout.upload_workouts(
+        workout.WorkoutUploadConfig(
+            igp_user="u",
+            igp_password="p",
+            intervals_api_key="k",
+            workout_days_ahead=1,
+        )
+    )
+    assert captured["oldest"] == today
+    assert captured["newest"] == today

--- a/uv.lock
+++ b/uv.lock
@@ -105,7 +105,7 @@ wheels = [
 
 [[package]]
 name = "flet"
-version = "0.85.2"
+version = "0.85.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx", marker = "sys_platform != 'emscripten'" },
@@ -113,33 +113,33 @@ dependencies = [
     { name = "oauthlib", marker = "sys_platform != 'emscripten'" },
     { name = "repath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/8c/277e92494a15aa8e630aebb55f8db8fc6dacbd18a8618df4e046acd5e214/flet-0.85.2.tar.gz", hash = "sha256:17ad1958cc82a17cca32716413eb07b0145641c9ba3f5055ec9341b6146aef60", size = 508302, upload-time = "2026-05-25T17:32:51.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/9f/fd4d2adfe7220291242ca6d16879706cfdf4581190c69b271cc3ce214ee8/flet-0.85.3.tar.gz", hash = "sha256:5b606cd86da5866e7071e991dbe4019f09c69360f5993f8c47f93f05aee4ea42", size = 509336, upload-time = "2026-06-08T01:56:39.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/38/8dc6aadd870ba4138b0bc6727ad83965e428c0b29f34dcd51fa478e2dceb/flet-0.85.2-py3-none-any.whl", hash = "sha256:b2839fabf25e2db4c716ac9e0d973c6dd2fc62082d843469684ce986d0556b57", size = 582803, upload-time = "2026-05-25T17:32:53.187Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b0/f2dc1ce301c88911046f7da4e8f1efa4418cb4b24fa326c391ec54b5f0f6/flet-0.85.3-py3-none-any.whl", hash = "sha256:c486adc2b6b7640ace3a614e450c5a02f731ef4698e0f0c9b823a6b906484236", size = 582912, upload-time = "2026-06-08T01:56:40.31Z" },
 ]
 
 [[package]]
 name = "flet-permission-handler"
-version = "0.85.2"
+version = "0.85.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flet" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/f3/1f90351acc3c17769cb8268aed3f58f8b0064c738782e9cba5a36edac2bd/flet_permission_handler-0.85.2.tar.gz", hash = "sha256:0a1d05538c34ad305980643f25c9ed05f66f2d81d787259083db0b6464eb7ab1", size = 12241, upload-time = "2026-05-25T17:33:40.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/0e/0a4c8beadb7423a06fdcc6aeaa4b6c9f5393eaa59dcc9cfe710cc56a67d1/flet_permission_handler-0.85.3.tar.gz", hash = "sha256:7f2fc4bf5cdb0a7a64c78b6913a0ae0d2dfa8538ec9ade3ac19070f1e4a131a6", size = 12258, upload-time = "2026-06-08T01:57:20.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/93/348a0c1259c176b7a7f903dc08692696c7640e9385a6217df8fe21fcc02f/flet_permission_handler-0.85.2-py3-none-any.whl", hash = "sha256:58072efa14d953c15a7137f50d448d1fd6c4e304f26cf482e386a3a7a2a549d3", size = 13552, upload-time = "2026-05-25T17:33:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/56/c7202d2eed61387d4b344e4e0fe69219575aaace91298210bb6f85ae5cce/flet_permission_handler-0.85.3-py3-none-any.whl", hash = "sha256:1d8d0b87136a8f6fa97c04380d7791d599e577b225e8a6ac7b71dc0c7c211cb8", size = 13552, upload-time = "2026-06-08T01:57:19.413Z" },
 ]
 
 [[package]]
 name = "flet-secure-storage"
-version = "0.85.2"
+version = "0.85.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flet" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/57/d925083d5bc636ea64b1ac1182cf6bdc00403f75d03ec671603129786a17/flet_secure_storage-0.85.2.tar.gz", hash = "sha256:c788c27474ae3c7843930582e03bb624b3f7cd30026123fa1979b1f741d4b9e6", size = 15689, upload-time = "2026-05-25T17:33:43.821Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/ea/edf5185770d49b0ff7f8cce77ff57155b6b35fd5161879a84ee154513348/flet_secure_storage-0.85.3.tar.gz", hash = "sha256:4870aac748c29696c9cb7717ea7662e9ace068a8ac3e5ca08e0ec9692256c5c8", size = 15688, upload-time = "2026-06-08T01:57:23.768Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/10/2d68c54e56e037e6e61271a475071b9452d85b1f325b709702e80f1e8db4/flet_secure_storage-0.85.2-py3-none-any.whl", hash = "sha256:41cccb04b54c458847e127cc5005e38698d58d401230e74ff6c1e5f297d72cf5", size = 16550, upload-time = "2026-05-25T17:33:44.544Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cb/70308b53dee319a5357ab5caef6efe46b48fe66b83d9de543d0cf2fc6424/flet_secure_storage-0.85.3-py3-none-any.whl", hash = "sha256:06cdee4004183acb0fc55dd3ab615cb2387e2c4e17d0c0e0f3c0d9e64cda16c5", size = 16550, upload-time = "2026-06-08T01:57:24.408Z" },
 ]
 
 [[package]]
@@ -210,9 +210,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dropbox", specifier = ">=12.0.2" },
-    { name = "flet", specifier = ">=0.28" },
-    { name = "flet-permission-handler", specifier = ">=0.85.2" },
-    { name = "flet-secure-storage", specifier = ">=0.85.2" },
+    { name = "flet", specifier = ">=0.85.3" },
+    { name = "flet-permission-handler", specifier = ">=0.85.3" },
+    { name = "flet-secure-storage", specifier = ">=0.85.3" },
     { name = "packaging", specifier = ">=26.2" },
     { name = "platformdirs", specifier = ">=4.0" },
     { name = "requests", specifier = ">=2.33.1" },


### PR DESCRIPTION
## Summary
- Add GUI upload of intervals.icu planned workouts to iGPSPORT via the mobile EditCustomWorkOut API, with idempotent tracking and a configurable upload window in Settings
- Document workout upload in the README
- Bump Flet to 0.85.3 to fix Windows CI on MSVC 14.51+

## Test plan
- [ ] Run `uv run pytest` and confirm all tests pass
- [ ] Configure iGPSPORT and intervals.icu credentials, sync planned workouts, and verify they appear on the device
- [ ] Confirm idempotent re-sync does not duplicate workouts
- [ ] Adjust upload window in Settings and verify only workouts in range are uploaded
- [ ] Verify Windows CI passes on the merged commit
