### PR TITLE
docs: lean README, surface CLI workflow, and add badges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ Run the app while developing:
 uv run main.py          # launch the GUI
 ```
 
+Headless sync and agent integration: [docs/AGENT.md](docs/AGENT.md).
+
 ## Running the tests
 
 ```bash
@@ -93,14 +95,45 @@ share the production app's rate limit.
 - The Flet API changes between versions — verify control arguments against the
   installed version (currently 0.85.x) rather than older tutorials.
 
-## Releases (maintainers)
+## Cutting a release
 
-Releases are built by GitHub Actions when a version tag is pushed:
+Releases are built automatically by GitHub Actions (`.github/workflows/release.yml`)
+whenever you push a version tag. To publish a new version:
 
 ```bash
-git tag v0.2.0
-git push origin v0.2.0
+git tag v0.1.0      # pick the next version number
+git push origin v0.1.0
 ```
 
-This builds the Windows app and attaches it to a new GitHub Release. See
-`.github/workflows/release.yml`.
+The workflow builds the Windows app **and the Android APK** on clean runners and
+attaches both (`igpsport-intervals-windows.zip` and an `.apk`) to a new GitHub
+Release. Watch it run under the repo's **Actions** tab; the result appears under
+**Releases**.
+
+### Pre-releases (test a build before shipping)
+
+Tag with a hyphen, e.g. `v0.3.0-rc1`, to publish a **pre-release**. It still
+builds installable artifacts you can test on a device, but GitHub keeps the last
+stable as **Latest** and the in-app update check ignores it — so users on the
+stable version aren't notified. Once it's good, tag the final `v0.3.0`.
+
+### Urgent hotfix while `master` has unreleased work
+
+`master` only ever contains finished, merged PRs, so usually you can just merge
+the fix and tag a patch. If `master` already has work you're not ready to ship,
+branch the fix from the **last released tag** instead, so only the fix goes out:
+
+```bash
+# 1. Branch from the last released tag (NOT master):
+git switch -c hotfix/v0.2.5 v0.2.4
+# 2. Commit the fix on this branch, then push it:
+git push -u origin hotfix/v0.2.5
+# 3. Tag this branch's fix commit -> builds & publishes only the fix:
+git tag v0.2.5 && git push origin v0.2.5
+# 4. Open a PR from hotfix/v0.2.5 into master and merge it, so the fix is
+#    also in master for future work (master is protected, so use a PR).
+```
+
+The tag points at the hotfix commit, so the build contains just the fix — none
+of master's unreleased work. The merge into master (step 4) is separate and
+happens *after* tagging.

--- a/README.md
+++ b/README.md
@@ -46,20 +46,7 @@ isn't on the Play Store, so the "unknown source" prompt is expected.
 
 ## CLI & automation (AI agents)
 
-The `igpsync` CLI runs the same activity sync without the GUI — useful for
-scripts and automation agents (e.g. [Hermes](https://hermes-agent.nousresearch.com))
-that detect new rides and need a reliable upload step.
-
-Requires [uv](https://docs.astral.sh/uv/) and a clone of this repo:
-
-```bash
-uv sync
-uv run igpsync check          # verify credentials in .env
-uv run igpsync sync --json    # sync; result on stdout, progress on stderr
-```
-
-Credentials go in a `.env` file (not the GUI secure vault). Full setup,
-Hermes profile paths, flags, and JSON schema: [Agent / headless sync](docs/AGENT.md).
+Headless `igpsync` CLI for scripts and AI agents ([Hermes](https://hermes-agent.nousresearch.com), [OpenClaw](https://openclaw.ai/)) — same sync as the GUI, JSON on stdout, credentials in `.env`. Setup, flags, and invocation: [Agent / headless sync](docs/AGENT.md).
 
 ## Run from source
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # iGPSPORT → intervals.icu
 
+[![License: MIT](https://img.shields.io/github/license/jorge-huxley/igpsport-intervals)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.13%2B-blue)](https://www.python.org/downloads/)
+[![Tests](https://github.com/jorge-huxley/igpsport-intervals/actions/workflows/test.yml/badge.svg)](https://github.com/jorge-huxley/igpsport-intervals/actions/workflows/test.yml)
+[![GitHub release](https://img.shields.io/github/v/release/jorge-huxley/igpsport-intervals)](https://github.com/jorge-huxley/igpsport-intervals/releases)
+[![Platforms](https://img.shields.io/badge/platforms-Windows%20%7C%20Android-lightgrey)](#download--run-windows)
+[![Stars](https://img.shields.io/github/stars/jorge-huxley/igpsport-intervals?label=stars)](https://github.com/jorge-huxley/igpsport-intervals/stargazers)
+
 A small, friendly app that syncs your cycling activities between **iGPSPORT** and
 **intervals.icu**. It's built for non-technical riders — no command line, no config
 files: enter your credentials once, press **Sync**, and your latest rides land on

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ source, for **Windows** and **Android**.
 - Optionally deletes the local `.fit` files after a successful upload
 - Stores your credentials in the **OS secure vault** (Windows Credential Manager / Android Keystore), never in a file
 - Lets you know when a newer version is available
+- **Headless CLI** — same sync pipeline from the terminal, with JSON output and exit codes for automation and AI agents (see [CLI & automation](#cli--automation-ai-agents))
 
-> Prefer the terminal, or want to help out? It's open source (Python + [Flet](https://flet.dev), MIT) — see [Run from source](#run-from-source), [Agent / headless sync](docs/AGENT.md), and [CONTRIBUTING.md](CONTRIBUTING.md).
+> Prefer the terminal, or want to help out? It's open source (Python + [Flet](https://flet.dev), MIT) — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Download & run (Windows)
 
@@ -43,6 +44,23 @@ Windows uses for its own logins) — never in a plain text file.
 On Android your credentials are stored in the **Android Keystore**. The app
 isn't on the Play Store, so the "unknown source" prompt is expected.
 
+## CLI & automation (AI agents)
+
+The `igpsync` CLI runs the same activity sync without the GUI — useful for
+scripts and automation agents (e.g. [Hermes](https://hermes-agent.nousresearch.com))
+that detect new rides and need a reliable upload step.
+
+Requires [uv](https://docs.astral.sh/uv/) and a clone of this repo:
+
+```bash
+uv sync
+uv run igpsync check          # verify credentials in .env
+uv run igpsync sync --json    # sync; result on stdout, progress on stderr
+```
+
+Credentials go in a `.env` file (not the GUI secure vault). Full setup,
+Hermes profile paths, flags, and JSON schema: [Agent / headless sync](docs/AGENT.md).
+
 ## Run from source
 
 Requires [uv](https://docs.astral.sh/uv/).
@@ -61,49 +79,6 @@ uv run flet build windows
 
 The distributable lands in `build/windows/`. (Flet downloads the Flutter
 toolchain on the first build.)
-
-## Cutting a release
-
-Releases are built automatically by GitHub Actions (`.github/workflows/release.yml`)
-whenever you push a version tag. To publish a new version:
-
-```bash
-git tag v0.1.0      # pick the next version number
-git push origin v0.1.0
-```
-
-The workflow builds the Windows app **and the Android APK** on clean runners and
-attaches both (`igpsport-intervals-windows.zip` and an `.apk`) to a new GitHub
-Release. Watch it run under the repo's **Actions** tab; the result appears under
-**Releases**.
-
-### Pre-releases (test a build before shipping)
-
-Tag with a hyphen, e.g. `v0.3.0-rc1`, to publish a **pre-release**. It still
-builds installable artifacts you can test on a device, but GitHub keeps the last
-stable as **Latest** and the in-app update check ignores it — so users on the
-stable version aren't notified. Once it's good, tag the final `v0.3.0`.
-
-### Urgent hotfix while `master` has unreleased work
-
-`master` only ever contains finished, merged PRs, so usually you can just merge
-the fix and tag a patch. If `master` already has work you're not ready to ship,
-branch the fix from the **last released tag** instead, so only the fix goes out:
-
-```bash
-# 1. Branch from the last released tag (NOT master):
-git switch -c hotfix/v0.2.5 v0.2.4
-# 2. Commit the fix on this branch, then push it:
-git push -u origin hotfix/v0.2.5
-# 3. Tag this branch's fix commit -> builds & publishes only the fix:
-git tag v0.2.5 && git push origin v0.2.5
-# 4. Open a PR from hotfix/v0.2.5 into master and merge it, so the fix is
-#    also in master for future work (master is protected, so use a PR).
-```
-
-The tag points at the hotfix commit, so the build contains just the fix — none
-of master's unreleased work. The merge into master (step 4) is separate and
-happens *after* tagging.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Move the full release guide (tag workflow, pre-releases, hotfix-from-tag) from README to CONTRIBUTING
- Add a brief CLI & automation section for AI agents (Hermes, OpenClaw) pointing to docs/AGENT.md
- Add README badges: license, Python 3.13+, CI status, latest release, platforms, and stars

## Test plan
- [ ] README renders correctly on GitHub (badges, links, anchors)
- [ ] CONTRIBUTING release section links and code blocks look correct
- [ ] CLI section links to docs/AGENT.md

Made with [Cursor](https://cursor.com)