### PR TITLE
feat(cli): add upload-workouts subcommand and improve credential errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
-# Local development only. Copy to .env and run: uv run --env-file .env main.py
+# Local development only. Copy to .env and run:
+#   uv run --env-file .env main.py          # GUI
+#   uv run --env-file .env igpsync sync     # CLI activity sync
+#   uv run --env-file .env igpsync upload-workouts   # CLI workout upload
 #
+# IGPSYNC_IGP_* and IGPSYNC_INTERVALS_API_KEY are required for the CLI.
 # Dropbox app key for the optional Dropbox upload. Create your own app at
 # https://www.dropbox.com/developers/apps (see CONTRIBUTING.md for scopes).
 # Leave blank to keep the Dropbox feature disabled. The .env file is gitignored.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-A cross-platform app that exports cycling activities from iGPSPORT and uploads them to intervals.icu. It ships as a **Flet** GUI (Python, renders via Flutter — desktop now, Android/iOS later). Dependency/environment management is done with [uv](https://docs.astral.dev/uv/) (Python 3.13).
+A cross-platform app that syncs cycling activities and planned workouts between iGPSPORT and intervals.icu. It ships as a **Flet** GUI (Python, renders via Flutter — desktop now, Android/iOS later) plus a headless **CLI** for automation. Dependency/environment management is done with [uv](https://docs.astral.dev/uv/) (Python 3.13).
 
 ## Commands
 
 ```bash
 uv sync                 # install/lock dependencies into .venv
 uv run main.py          # launch the GUI
+uv run igpsync sync --json              # headless activity sync
+uv run igpsync upload-workouts --json   # headless workout upload
+uv run igpsync check                    # validate CLI credentials
 uv run flet build windows   # build the distributable Windows .exe (build/windows/)
 uv run pytest               # run the test suite
 ```
@@ -25,12 +28,14 @@ uv run pytest               # run the test suite
 
 The code is split so that going mobile later changes mostly just packaging; core, storage, and most UI stay put. All packages live under `src/igpsync/`.
 
-- **Core (`core.py`)** — pure sync logic, no UI and no module-level side effects. `sync(SyncConfig, progress)` drives the four steps and reports via a `progress(message)` callback so callers can render it however they like. Raises `SyncError` / `AuthError` for friendly messages. Functions: `login`, `list_activities`, `resolve_fit_url`, `download_fit`, `upload_to_intervals`.
+- **Core (`core.py`)** — pure activity sync logic, no UI and no module-level side effects. `sync(SyncConfig, progress)` drives the four steps and reports via a `progress(message)` callback so callers can render it however they like. Raises `SyncError` / `AuthError` for friendly messages. Functions: `login`, `list_activities`, `resolve_fit_url`, `download_fit`, `upload_to_intervals`.
+- **Workouts (`workout.py`)** — planned workout upload (intervals.icu → iGPSPORT). `upload_workouts(WorkoutUploadConfig, progress)` fetches calendar events and pushes custom workouts via the iGPSPORT mobile JSON API. UI-free; used by GUI and CLI.
+- **CLI (`cli.py`, `cli_env.py`, `cli_config.py`)** — headless `igpsync` entry with `check`, `sync`, and `upload-workouts` subcommands. Credentials from `.env`; non-secret settings in `igpsync-cli` `config.json`. See `docs/AGENT.md`.
 - **Storage**
   - `secrets.py` — `SecretStore` **async** ABC + `FletSecureStorage`. Secrets (`igp_password`, `intervals_api_key`) live in the **OS-native vault** via the `flet-secure-storage` service (Windows Credential Manager / macOS+iOS Keychain / Android Keystore / Linux libsecret), never in a file. Same backend on every platform — no per-OS branching. It's async and page-bound, so the `SecureStorage` service must be registered (`page.services.append(...)`) before use and all secret access is `await`ed.
-  - `config.py` — non-secret settings (`igp_user`, step toggles, `max_activities`, `download_dir`, `activity_type`) as JSON in `platformdirs.user_config_dir`.
-- **GUI (`gui/`)** — `app.py` (async entry `ft.run(_app)`, Material 3 theme, app-bar routing; registers the secure-storage service), `settings_view.py` (async; credential inputs → secure storage), `sync_view.py` (one-click "Sync activities", progress bar + live log). Because secret access is async but `core.sync` runs on a worker thread via `page.run_thread`, the sync view resolves secrets to plain strings in the async click handler and passes them into the thread. First run with no saved credentials opens Settings. Uses the **imperative** Flet style; the 0.85 declarative `@ft.component` / `ft.use_dialog` API is an alternative we don't use.
-- **`main.py`** — entry shim that puts `src/` on the path and launches the GUI (`igpsync.gui.app.main`). The GUI is the only entry point.
+  - `config.py` — non-secret GUI settings (`igp_user`, step toggles, `max_activities`, `download_dir`, `activity_type`, `uploaded_workouts`, `workout_days_ahead`) as JSON in `platformdirs.user_config_dir`.
+- **GUI (`gui/`)** — `app.py` (async entry `ft.run(_app)`, Material 3 theme, app-bar routing; registers the secure-storage service), `settings_view.py` (async; credential inputs → secure storage), `sync_view.py` ("Sync activities" and "Upload workouts", progress bar + live log). Because secret access is async but `core.sync` runs on a worker thread via `page.run_thread`, the sync view resolves secrets to plain strings in the async click handler and passes them into the thread. First run with no saved credentials opens Settings. Uses the **imperative** Flet style; the 0.85 declarative `@ft.component` / `ft.use_dialog` API is an alternative we don't use.
+- **`main.py`** — entry shim that puts `src/` on the path and launches the GUI (`igpsync.gui.app.main`).
 
 ## Flow / external API notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ minimal change (see `CLAUDE.md` for the full picture):
 
 - `src/igpsync/core.py` — pure sync logic (no UI, no side effects)
 - `src/igpsync/config.py` + `secrets.py` — settings (JSON) and secrets (OS vault)
-- `src/igpsync/gui/` — the Flet UI; `cli.py` / `main.py` — the headless entry
+- `src/igpsync/gui/` — the Flet UI (`main.py` / `igpsync-gui` entry)
+- `src/igpsync/cli.py` — headless CLI (`igpsync` entry; see `docs/AGENT.md`)
 
 Keep new logic in `core` testable and UI-free; the GUI and CLI should stay thin.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ source, for **Windows** and **Android**.
 - Optionally deletes the local `.fit` files after a successful upload
 - Stores your credentials in the **OS secure vault** (Windows Credential Manager / Android Keystore), never in a file
 - Lets you know when a newer version is available
-- **Headless CLI** — same sync pipeline from the terminal, with JSON output and exit codes for automation and AI agents (see [CLI & automation](#cli--automation-ai-agents))
+- **Headless CLI** — activity sync and workout upload from the terminal, with JSON output and exit codes for automation and AI agents (see [CLI & automation](#cli--automation-ai-agents))
 
 > Prefer the terminal, or want to help out? It's open source (Python + [Flet](https://flet.dev), MIT) — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -53,7 +53,7 @@ isn't on the Play Store, so the "unknown source" prompt is expected.
 
 ## CLI & automation (AI agents)
 
-Headless `igpsync` CLI for scripts and AI agents ([Hermes](https://hermes-agent.nousresearch.com), [OpenClaw](https://openclaw.ai/)) — same sync as the GUI, JSON on stdout, credentials in `.env`. Setup, flags, and invocation: [Agent / headless sync](docs/AGENT.md).
+Headless `igpsync` CLI for scripts and AI agents ([Hermes](https://hermes-agent.nousresearch.com), [OpenClaw](https://openclaw.ai/)) — sync activities to intervals.icu, upload planned workouts to iGPSPORT, JSON on stdout, credentials in `.env`. Setup, flags, and invocation: [Agent / headless sync](docs/AGENT.md).
 
 ## Run from source
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1,9 +1,9 @@
 # Agent / headless sync
 
-Use the `igpsync` CLI to upload recent rides from iGPSPORT to intervals.icu
+Use the `igpsync` CLI to sync cycling data between iGPSPORT and intervals.icu
 without the GUI. It is designed for automation agents (e.g.
-[Hermes](https://hermes-agent.nousresearch.com)) that already detect new
-activities and only need a reliable upload trigger.
+[Hermes](https://hermes-agent.nousresearch.com)) that need reliable upload
+triggers for activities and/or planned workouts.
 
 ## Prerequisites
 
@@ -71,6 +71,8 @@ Optional: pass `--env-file /path/to/.env` to override auto-detection.
 
 ## Agent invocation
 
+### Activity sync (iGPSPORT → intervals.icu)
+
 From the repository root:
 
 ```bash
@@ -101,6 +103,27 @@ Example success output:
 }
 ```
 
+### Workout upload (intervals.icu → iGPSPORT)
+
+```bash
+uv run igpsync upload-workouts --json
+```
+
+Example success output:
+
+```json
+{
+  "ok": true,
+  "listed": 3,
+  "uploaded": 1,
+  "skipped": 1,
+  "no_steps": 1,
+  "failed": 0
+}
+```
+
+Same progress/exit-code rules as activity sync.
+
 Example credential error:
 
 ```json
@@ -115,27 +138,53 @@ handle or write secrets.
 
 ## Optional flags
 
+Shared by all subcommands:
+
+| Flag              | Purpose                        |
+| ----------------- | ------------------------------ |
+| `--env-file PATH` | Override secrets file location |
+| `--json`          | Machine-readable JSON on stdout (progress on stderr) |
+
+`sync` flags:
 
 | Flag                   | Purpose                                        |
 | ---------------------- | ---------------------------------------------- |
-| `--env-file PATH`      | Override secrets file location                 |
 | `--max-activities N`   | Number of recent rides to process (default: 5) |
 | `--force-resync`       | Re-upload even if already on intervals.icu     |
 | `--activity-type TYPE` | Set intervals.icu sport after upload           |
 | `--download-dir PATH`  | Directory for temporary `.fit` files           |
 | `--keep-files`         | Do not delete `.fit` files after upload        |
 
+`upload-workouts` flags:
+
+| Flag                     | Purpose                                              |
+| ------------------------ | ---------------------------------------------------- |
+| `--workout-days-ahead N` | Calendar days to upload (default: 1 = today only)    |
+| `--force-resync`         | Re-upload even if already on iGPSPORT                |
+
 
 ## Subcommands
 
 
-| Command         | Description                                                         |
-| --------------- | ------------------------------------------------------------------- |
-| `igpsync sync`  | Full pipeline: list → download → upload to intervals.icu            |
-| `igpsync check` | Validate `.env` exists and has all three required keys (no network) |
+| Command                    | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `igpsync sync`             | Full pipeline: list → download → upload to intervals.icu            |
+| `igpsync upload-workouts`  | Upload planned workouts from intervals.icu to iGPSPORT              |
+| `igpsync check`            | Validate `.env` exists and has all three required keys (no network) |
+
+
+## CLI config
+
+Non-secret defaults are persisted in `config.json` under the `igpsync-cli`
+app config directory (`platformdirs`). CLI flags override these per run.
+Fields include `max_activities`, `workout_days_ahead`, `force_resync`,
+`uploaded_workouts` (intervals.icu event id → iGPSPORT workoutId dedup map),
+and activity-sync settings. Secrets never go in this file.
 
 
 ## What it does
+
+### Activity sync (`sync`)
 
 Same as the GUI one-click sync:
 
@@ -144,4 +193,14 @@ Same as the GUI one-click sync:
 - Downloads `.fit` files and uploads to intervals.icu
 - Deletes local `.fit` files after successful upload (unless `--keep-files`)
 - Does **not** upload to Dropbox
+
+### Workout upload (`upload-workouts`)
+
+Same as the GUI **Upload workouts** button:
+
+- Fetches planned cycling workouts from the intervals.icu calendar
+- Skips workouts already uploaded (unless `--force-resync`)
+- Skips non-cycling activity types (v1)
+- Skips workouts with no structured steps (`no_steps` in JSON) — open the workout in intervals.icu first
+- Persists the `uploaded_workouts` dedup map in CLI `config.json` after each run
 

--- a/src/igpsync/cli.py
+++ b/src/igpsync/cli.py
@@ -1,7 +1,10 @@
-"""Headless CLI for syncing iGPSPORT activities to intervals.icu.
+"""Headless CLI for iGPSPORT ↔ intervals.icu sync.
 
 Designed for agent use (e.g. Hermes): credentials are read from the profile
 .env file; progress goes to stderr; structured results go to stdout with --json.
+
+Subcommands: activity sync (iGPSPORT → intervals.icu) and workout upload
+(intervals.icu → iGPSPORT).
 """
 
 from __future__ import annotations
@@ -14,6 +17,7 @@ from pathlib import Path
 from . import cli_config as cli_config_module
 from .cli_env import CliConfigError, load_credentials, resolve_env_path
 from .core import SyncConfig, SyncError, SyncResult, sync
+from .workout import WorkoutUploadConfig, WorkoutUploadResult, upload_workouts
 
 EXIT_OK = 0
 EXIT_SYNC_ERROR = 1
@@ -80,6 +84,50 @@ def _emit_text_summary(result: SyncResult) -> None:
         f"Done — uploaded {result.uploaded}, "
         f"downloaded {result.downloaded}, "
         f"skipped {result.skipped}, "
+        f"failed {result.failed}."
+    )
+
+
+def _build_workout_upload_config(
+    credentials,
+    config: cli_config_module.CliConfig,
+    *,
+    workout_days_ahead: int | None,
+    force_resync: bool | None,
+) -> WorkoutUploadConfig:
+    return WorkoutUploadConfig(
+        igp_user=credentials.igp_user,
+        igp_password=credentials.igp_password,
+        intervals_api_key=credentials.intervals_api_key,
+        workout_days_ahead=(
+            workout_days_ahead if workout_days_ahead is not None else config.workout_days_ahead
+        ),
+        uploaded_workouts=dict(config.uploaded_workouts),
+        force_resync=force_resync if force_resync is not None else config.force_resync,
+    )
+
+
+def _workout_result_payload(
+    result: WorkoutUploadResult, *, ok: bool, error: str | None = None
+) -> dict:
+    payload = {
+        "ok": ok,
+        "listed": result.listed,
+        "uploaded": result.uploaded,
+        "skipped": result.skipped,
+        "failed": result.failed,
+        "no_steps": result.no_steps,
+    }
+    if error is not None:
+        payload["error"] = error
+    return payload
+
+
+def _emit_workout_text_summary(result: WorkoutUploadResult) -> None:
+    print(
+        f"Done — uploaded {result.uploaded}, "
+        f"skipped {result.skipped}, "
+        f"no steps {result.no_steps}, "
         f"failed {result.failed}."
     )
 
@@ -162,6 +210,61 @@ def cmd_sync(args: argparse.Namespace) -> int:
     return EXIT_OK if ok else EXIT_SYNC_ERROR
 
 
+def cmd_upload_workouts(args: argparse.Namespace) -> int:
+    config = cli_config_module.load()
+    use_json = args.json
+
+    try:
+        env_path = resolve_env_path(
+            env_file=Path(args.env_file) if args.env_file else None,
+            config_env_file=config.env_file or None,
+        )
+        credentials = load_credentials(env_path)
+    except CliConfigError as exc:
+        if use_json:
+            _emit_json({"ok": False, "error": str(exc)})
+        else:
+            print(exc, file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    upload_config = _build_workout_upload_config(
+        credentials,
+        config,
+        workout_days_ahead=args.workout_days_ahead,
+        force_resync=True if args.force_resync else None,
+    )
+
+    def progress(message: str) -> None:
+        print(message, file=sys.stderr)
+
+    try:
+        result = upload_workouts(upload_config, progress=progress)
+    except SyncError as exc:
+        if use_json:
+            _emit_json(_workout_result_payload(WorkoutUploadResult(), ok=False, error=str(exc)))
+        else:
+            print(f"✗ {exc}", file=sys.stderr)
+        return EXIT_SYNC_ERROR
+    except Exception as exc:  # noqa: BLE001 — surface unexpected failures to agents
+        if use_json:
+            _emit_json(_workout_result_payload(WorkoutUploadResult(), ok=False, error=str(exc)))
+        else:
+            print(f"✗ Unexpected error: {exc}", file=sys.stderr)
+        return EXIT_SYNC_ERROR
+
+    if result.uploaded_map:
+        config.uploaded_workouts.update(result.uploaded_map)
+        cli_config_module.save(config)
+
+    ok = result.failed == 0
+    if use_json:
+        _emit_json(_workout_result_payload(result, ok=ok))
+    else:
+        _emit_workout_text_summary(result)
+
+    return EXIT_OK if ok else EXIT_SYNC_ERROR
+
+
 def _build_parser() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument(
@@ -177,7 +280,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     parser = argparse.ArgumentParser(
         prog="igpsync",
-        description="Sync cycling activities from iGPSPORT to intervals.icu.",
+        description="Sync cycling activities and planned workouts between iGPSPORT and intervals.icu.",
     )
 
     subparsers = parser.add_subparsers(dest="command")
@@ -222,6 +325,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Keep .fit files after upload instead of deleting them.",
     )
     sync_parser.set_defaults(func=cmd_sync)
+
+    upload_workouts_parser = subparsers.add_parser(
+        "upload-workouts",
+        parents=[common],
+        help="Upload planned workouts from intervals.icu to iGPSPORT.",
+    )
+    upload_workouts_parser.add_argument(
+        "--workout-days-ahead",
+        type=int,
+        metavar="N",
+        help="Number of calendar days to upload (default: from cli config).",
+    )
+    upload_workouts_parser.add_argument(
+        "--force-resync",
+        action="store_true",
+        help="Re-upload workouts even if already on iGPSPORT.",
+    )
+    upload_workouts_parser.set_defaults(func=cmd_upload_workouts)
 
     return parser
 

--- a/src/igpsync/cli_config.py
+++ b/src/igpsync/cli_config.py
@@ -31,6 +31,10 @@ class CliConfig:
     delete_after_upload: bool = True
     force_resync: bool = False
     activity_type: str = ""
+    # Planned workouts: intervals.icu event id → iGPSPORT workoutId.
+    uploaded_workouts: dict[str, int] = field(default_factory=dict)
+    # How many calendar days of planned workouts to upload (1 = today only).
+    workout_days_ahead: int = 1
 
 
 def load() -> CliConfig:

--- a/src/igpsync/cli_env.py
+++ b/src/igpsync/cli_env.py
@@ -17,14 +17,47 @@ INTERVALS_API_KEY_KEY = "IGPSYNC_INTERVALS_API_KEY"
 
 REQUIRED_KEYS = (IGP_USER_KEY, IGP_PASSWORD_KEY, INTERVALS_API_KEY_KEY)
 
+_CREDENTIALS_BODY = (
+    f"  {IGP_USER_KEY}=<email>\n"
+    f"  {IGP_PASSWORD_KEY}=<password>\n"
+    f"  {INTERVALS_API_KEY_KEY}=<api-key>"
+)
+
+ENV_OVERRIDE_HINT = (
+    "Point igpsync at a different file:\n"
+    "  igpsync <command> --env-file /path/to/.env\n"
+    "You can also set env_file in the igpsync-cli config.json."
+)
+
 SETUP_HINT = (
-    "Ask the user to append all three keys to their Hermes profile .env "
+    "Ask the user to add all three keys to their Hermes profile .env "
     "(replace {profile_home} with the profile directory, e.g. "
-    "~/.hermes/profiles/coach):\n"
+    "~/.hermes/profiles/coach). Do not use `hermes config set` for the "
+    "email or password — those belong in .env only:\n"
     f"  echo '{IGP_USER_KEY}=<email>' >> {{profile_home}}/.env\n"
     f"  echo '{IGP_PASSWORD_KEY}=<password>' >> {{profile_home}}/.env\n"
     f"  echo '{INTERVALS_API_KEY_KEY}=<api-key>' >> {{profile_home}}/.env"
 )
+
+
+def _secrets_file_not_found_message(env_path: Path) -> str:
+    return (
+        f"Secrets file not found: {env_path}\n\n"
+        f"Create that file with:\n{_CREDENTIALS_BODY}\n\n"
+        f"{ENV_OVERRIDE_HINT}\n\n"
+        "Default location: $HERMES_HOME/.env (active Hermes profile), or "
+        "~/.hermes/.env when HERMES_HOME is unset. For local development, "
+        "copy .env.example to .env and pass --env-file .env.\n\n"
+        f"{SETUP_HINT}"
+    )
+
+
+def _missing_keys_message(env_path: Path, missing: list[str]) -> str:
+    return (
+        f"Missing required keys in {env_path}: {', '.join(missing)}\n\n"
+        f"Add them to the file:\n{_CREDENTIALS_BODY}\n\n"
+        f"{SETUP_HINT}"
+    )
 
 
 class CliConfigError(Exception):
@@ -83,16 +116,12 @@ def parse_dotenv(text: str) -> dict[str, str]:
 def load_credentials(env_path: Path) -> CliCredentials:
     """Load and validate the three required credentials from a .env file."""
     if not env_path.is_file():
-        raise CliConfigError(
-            f"Secrets file not found: {env_path}\n{SETUP_HINT}"
-        )
+        raise CliConfigError(_secrets_file_not_found_message(env_path))
 
     values = parse_dotenv(env_path.read_text(encoding="utf-8"))
     missing = [key for key in REQUIRED_KEYS if not values.get(key)]
     if missing:
-        raise CliConfigError(
-            f"Missing required keys in {env_path}: {', '.join(missing)}\n{SETUP_HINT}"
-        )
+        raise CliConfigError(_missing_keys_message(env_path, missing))
 
     return CliCredentials(
         igp_user=values[IGP_USER_KEY],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from igpsync import cli, cli_config, cli_env, core
+from igpsync import cli, cli_config, cli_env, core, workout
 
 
 def _write_env(path: Path, **overrides: str) -> None:
@@ -40,6 +40,16 @@ def test_load_credentials_missing_keys(tmp_path: Path):
 
     with pytest.raises(cli_env.CliConfigError, match="IGPSYNC_IGP_PASSWORD"):
         cli_env.load_credentials(env_file)
+
+
+def test_load_credentials_missing_file_mentions_env_file(tmp_path: Path):
+    env_file = tmp_path / "missing.env"
+
+    with pytest.raises(cli_env.CliConfigError, match="--env-file") as exc_info:
+        cli_env.load_credentials(env_file)
+
+    assert "Secrets file not found" in str(exc_info.value)
+    assert ".env.example" in str(exc_info.value)
 
 
 def test_resolve_env_path_flag_wins(tmp_path: Path):
@@ -147,3 +157,67 @@ def test_cli_config_roundtrip(tmp_path: Path, monkeypatch):
     loaded = cli_config.load()
     assert loaded.env_file == "/custom/.env"
     assert loaded.max_activities == 10
+
+
+def test_upload_workouts_parser_accepts_flags():
+    args = cli._build_parser().parse_args(
+        ["upload-workouts", "--workout-days-ahead", "3", "--force-resync"]
+    )
+    assert args.command == "upload-workouts"
+    assert args.workout_days_ahead == 3
+    assert args.force_resync is True
+
+
+def test_upload_workouts_json_success(tmp_path: Path, monkeypatch, capsys):
+    env_file = tmp_path / ".env"
+    _write_env(env_file)
+    monkeypatch.setattr(cli_config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cli_config, "CONFIG_PATH", tmp_path / "config.json")
+
+    def fake_upload(config, progress=None):
+        if progress:
+            progress("uploading")
+        return workout.WorkoutUploadResult(
+            listed=2,
+            uploaded=1,
+            skipped=1,
+            uploaded_map={"42": 100},
+        )
+
+    monkeypatch.setattr(cli, "upload_workouts", fake_upload)
+
+    args = cli._build_parser().parse_args(
+        ["upload-workouts", "--env-file", str(env_file), "--json", "--workout-days-ahead", "2"]
+    )
+    assert cli.cmd_upload_workouts(args) == cli.EXIT_OK
+
+    captured = capsys.readouterr()
+    assert "uploading" in captured.err
+    payload = json.loads(captured.out)
+    assert payload["ok"] is True
+    assert payload["uploaded"] == 1
+    assert payload["skipped"] == 1
+    assert payload["no_steps"] == 0
+
+    loaded = cli_config.load()
+    assert loaded.uploaded_workouts == {"42": 100}
+    assert loaded.workout_days_ahead == 1
+
+
+def test_upload_workouts_json_sync_error(tmp_path: Path, monkeypatch, capsys):
+    env_file = tmp_path / ".env"
+    _write_env(env_file)
+
+    def fake_upload(config, progress=None):
+        raise core.SyncError("fetch failed")
+
+    monkeypatch.setattr(cli, "upload_workouts", fake_upload)
+
+    args = cli._build_parser().parse_args(
+        ["upload-workouts", "--env-file", str(env_file), "--json"]
+    )
+    assert cli.cmd_upload_workouts(args) == cli.EXIT_SYNC_ERROR
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"] == "fetch failed"


### PR DESCRIPTION
## Summary
- Add `igpsync upload-workouts` subcommand mirroring the GUI workout upload flow
- Persist `uploaded_workouts` dedup map and `workout_days_ahead` in CLI config
- Improve missing `.env` errors with `--env-file` and local dev guidance
- Update AGENT.md, README, CONTRIBUTING, CLAUDE.md, and `.env.example`

## Test plan
- [x] `uv run pytest tests/test_cli.py -v` (15 passed)
- [ ] `uv run igpsync upload-workouts --env-file .env` with valid credentials
- [ ] `uv run igpsync upload-workouts --help`

Made with [Cursor](https://cursor.com)