### PR TITLE
chore: add Ko-fi sponsor button via FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: jorge_huxley


### PR DESCRIPTION
## Summary
- Add \.github/FUNDING.yml\ with Ko-fi username \jorge_huxley\
- Enables GitHub's **Sponsor** button on the repository (Settings → Features → Sponsorships)

## Test plan
- [ ] Merge PR and confirm **Sponsor** button appears on the repo homepage
- [ ] Click **Sponsor** and verify it opens https://ko-fi.com/jorge_huxley