### PR TITLE
docs: add Ko-fi support badge and section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/jorge-huxley/igpsport-intervals)](https://github.com/jorge-huxley/igpsport-intervals/releases)
 [![Platforms](https://img.shields.io/badge/platforms-Windows%20%7C%20Android-lightgrey)](#download--run-windows)
 [![Stars](https://img.shields.io/github/stars/jorge-huxley/igpsport-intervals?label=stars)](https://github.com/jorge-huxley/igpsport-intervals/stargazers)
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/jorge_huxley)
 
 A small, friendly app that syncs your cycling activities between **iGPSPORT** and
 **intervals.icu**. It's built for non-technical riders — no command line, no config
@@ -79,6 +80,10 @@ toolchain on the first build.)
 The app is built with [Flet](https://flet.dev), so the same Python code targets
 desktop and Android today, with **iOS** (`flet build ipa`) possible from the same
 code.
+
+## Support
+
+Tips on [Ko-fi](https://ko-fi.com/jorge_huxley) help fund bug fixes, releases, and new features. Thank you!
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary
- Add official Ko-fi badge next to existing README badges
- Add a short **Support** section linking to https://ko-fi.com/jorge_huxley

## Test plan
- [ ] README renders the Ko-fi badge and Support section on GitHub

Made with [Cursor](https://cursor.com)