### PR TITLE
chore: remove duplicate custom link from FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 ko_fi: jorge_huxley
-custom: ["https://ko-fi.com/jorge_huxley"]


### PR DESCRIPTION
## Summary
- Remove the redundant `custom` Ko-fi URL from `.github/FUNDING.yml`
- Keep only the `ko_fi` entry for GitHub sponsor button integration

## Test plan
- [ ] Verify GitHub sponsor button still links to Ko-fi profile