### PR TITLE
docs: tidy features list formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@
 
 ## Features
 
-- Syncs recent rides from **iGPSPORT** or **Bryton Active** to intervals.icu (original `.fit` files)
-- **Optional Dropbox upload** — mirror activities to a Dropbox folder from the GUI (iGPSPORT or Bryton sync);
+- Syncs recent rides from **iGPSPORT** or **Bryton Active** to **intervals.icu** (original `.fit` files)
+- **Optional Dropbox upload** — mirror activities to a Dropbox folder from the GUI (iGPSPORT or Bryton sync)
 - **Upload workouts** — push planned cycling workouts from your intervals.icu calendar to iGPSPORT custom workouts or Bryton Active (sync to your head unit from the vendor app)
 - **Skips activities already uploaded** so re-running is safe — with an optional *force re-sync*
 - Lets you choose how many recent activities to process


### PR DESCRIPTION
## Summary
- Bold **intervals.icu** in the Features list for consistency with other product names
- Remove trailing semicolon from the Dropbox upload bullet for cleaner list formatting

## Test plan
- [x] Verified README renders correctly on GitHub
- [x] No functional or code changes