### PR TITLE
feat(igpsport): sync intervals.icu profile zones to iGPSPORT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 # Local development only. Copy to .env and run:
-#   uv run --env-file .env intervalssync-gui              # GUI
-#   uv run --env-file .env intervalssync sync             # iGPSPORT → intervals.icu
-#   uv run --env-file .env intervalssync sync --source bryton   # Bryton → intervals.icu
-#   uv run --env-file .env intervalssync upload-workouts   # intervals.icu → iGPSPORT workouts
+#   uv run --env-file .env intervalssync-gui                         # GUI (uv loads env)
+#   uv run intervalssync sync --env-file .env                        # iGPSPORT → intervals.icu
+#   uv run intervalssync sync --source bryton --env-file .env         # Bryton → intervals.icu
+#   uv run intervalssync upload-workouts --env-file .env               # intervals.icu → iGPSPORT workouts
+#   uv run intervalssync sync-zones --env-file .env                    # intervals.icu → iGPSPORT profile
 #
 # iGPSPORT sync requires INTERVALSSYNC_IGPSPORT_* + INTERVALSSYNC_INTERVALS_API_KEY.
 # Bryton sync requires INTERVALSSYNC_BRYTON_* + INTERVALSSYNC_INTERVALS_API_KEY.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ uv run intervalssync-gui
 uv run intervalssync sync                          # iGPSPORT (default)
 uv run intervalssync sync --source bryton          # Bryton Active
 uv run intervalssync upload-workouts --json        # intervals.icu → iGPSPORT
+uv run intervalssync sync-zones --env-file .env --json   # intervals.icu → iGPSPORT profile
 uv run intervalssync check --source bryton
 uv run flet build windows
 uv run pytest
@@ -36,8 +37,9 @@ src/intervalssync/
   intervals_icu.py, dropbox_client.py            # shared by sources
 ```
 
-- **`intervals_icu.py`** — shared upload, skip-existing (`external_id`), sport PUT, calendar workout fetch, sport-settings lookup (`max_hr`).
+- **`intervals_icu.py`** — shared upload, skip-existing (`external_id`), sport PUT, calendar workout fetch, sport-settings lookup (`fetch_sport_settings`, `max_hr`).
 - **`igpsport/core.py`** — `sync(SyncConfig, progress)`: login → list → FIT URL → download → upload. `external_id`: `igpsport_{ride_id}`.
+- **`igpsport/profile_sync.py`** — `sync_profile_zones`: intervals.icu sport settings → iGPSPORT profile thresholds/zones.
 - **`igpsport/workout.py`** — planned workouts intervals.icu → iGPSPORT.
 - **`bryton/ddp.py`** — Meteor DDP login + `activityList` subscription.
 - **`bryton/api.py`** — `GET https://m3.brytonactive.com/api/activity?id=…` (FIT download; Android app API).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@
 - Optionally deletes the local `.fit` files after a successful upload
 - Stores your credentials in the **OS secure vault** (Windows Credential Manager / Android Keystore), never in a file
 - Lets you know when a newer version is available
-- **Headless CLI** — activity sync and workout upload from the terminal, with JSON output and exit codes for automation and AI agents (see [CLI & automation](#cli--automation-ai-agents))
+- **Sync zones to iGPSPORT** — push FTP, LTHR, max HR, and power/HR zones from intervals.icu into your iGPSPORT profile (CLI for now)
+- **Headless CLI** — activity sync, workout upload, and iGPSPORT zone/threshold sync from the terminal, with JSON output and exit codes for automation and AI agents (see [CLI & automation](#cli--automation-ai-agents))
 
 > Prefer the terminal, or want to help out? It's open source (Python + [Flet](https://flet.dev), MIT) — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -92,7 +93,7 @@ isn't on the Play Store, so the "unknown source" prompt is expected.
 
 ## CLI & automation (AI agents)
 
-Headless `intervalssync` CLI — sync from iGPSPORT or Bryton, upload workouts to iGPSPORT or Bryton, JSON on stdout. See [Agent / headless sync](docs/AGENT.md).
+Headless `intervalssync` CLI — sync from iGPSPORT or Bryton, upload workouts to iGPSPORT or Bryton, sync thresholds and zones to iGPSPORT, JSON on stdout. See [Agent / headless sync](docs/AGENT.md).
 
 ## Run from source
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 - Optionally deletes the local `.fit` files after a successful upload
 - Stores your credentials in the **OS secure vault** (Windows Credential Manager / Android Keystore), never in a file
 - Lets you know when a newer version is available
-- **Sync zones to iGPSPORT** — push FTP, LTHR, max HR, and power/HR zones from intervals.icu into your iGPSPORT profile (CLI for now)
+- **Sync zones to iGPSPORT** — push FTP, LTHR, max HR, and power/HR zones from intervals.icu into your iGPSPORT profile (Settings → iGPSPORT profile, or `intervalssync sync-zones`; the app prompts on launch when thresholds differ)
 - **Headless CLI** — activity sync, workout upload, and iGPSPORT zone/threshold sync from the terminal, with JSON output and exit codes for automation and AI agents (see [CLI & automation](#cli--automation-ai-agents))
 
 > Prefer the terminal, or want to help out? It's open source (Python + [Flet](https://flet.dev), MIT) — see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -46,7 +46,8 @@ uv run intervalssync check                    # iGPSPORT keys
 uv run intervalssync check --source bryton      # Bryton keys
 ```
 
-Optional: `--env-file /path/to/.env`.
+Optional: `--env-file /path/to/.env` on the **intervalssync** command (e.g.
+`uv run intervalssync sync-zones --env-file .env`), not as a `uv run` flag.
 
 ## Agent invocation
 
@@ -86,6 +87,45 @@ uv run intervalssync upload-workouts --source bryton --json        # Bryton Acti
 
 Requires credentials for the chosen target. Same exit-code rules.
 
+### Zone sync (intervals.icu → iGPSPORT profile)
+
+```bash
+uv run intervalssync sync-zones --env-file .env --json
+```
+
+- **iGPSPORT-only** (no `--source` flag)
+- Reads FTP, LTHR, max HR, power zones, and HR zones from intervals.icu `sport-settings/Ride` (override with `--sport`)
+- Writes them to iGPSPORT via the mobile `UserIntervalInfo` API
+- Progress on **stderr**; result JSON on **stdout**; same exit codes as other commands
+
+Success example:
+
+```json
+{
+  "ok": true,
+  "source": "igpsport",
+  "before": {
+    "ftp": 240,
+    "lthr": 153,
+    "mhr": 193,
+    "power_zones": "0-132 | 132-180 | …",
+    "hr_zones": "0-120 | …"
+  },
+  "ftp": 242,
+  "lthr": 176,
+  "mhr": 193,
+  "power_zones": "0-133 | 133-182 | …",
+  "hr_zones": "0-120 | 120-146 | …",
+  "after": {
+    "ftp": 242,
+    "lthr": 176,
+    "mhr": 193,
+    "power_zones": "0-133 | 133-182 | …",
+    "hr_zones": "0-120 | 120-146 | …"
+  }
+}
+```
+
 ## Optional flags
 
 | Flag | Purpose |
@@ -93,6 +133,7 @@ Requires credentials for the chosen target. Same exit-code rules.
 | `--source {igpsport,bryton}` | Activity source or workout upload target (default: igpsport) |
 | `--env-file PATH` | Override secrets file |
 | `--json` | JSON on stdout |
+| `--sport TYPE` | intervals.icu sport-settings key for `sync-zones` (default: Ride) |
 
 `sync` flags: `--max-activities`, `--force-resync`, `--activity-type`, `--download-dir`, `--keep-files`.
 
@@ -102,6 +143,7 @@ Requires credentials for the chosen target. Same exit-code rules.
 |---------|-------------|
 | `intervalssync sync` | Download recent rides → upload to intervals.icu |
 | `intervalssync upload-workouts` | Planned workouts → iGPSPORT or Bryton (`--source`) |
+| `intervalssync sync-zones` | Push thresholds + zones from intervals.icu → iGPSPORT profile |
 | `intervalssync check` | Validate `.env` keys (no network) |
 
 ## CLI config
@@ -122,3 +164,7 @@ Non-secret defaults in `intervalssync-cli` `config.json` (`platformdirs`). Secre
 ### Workout upload
 
 Same as GUI **Upload to iGPSPORT** / **Upload to Bryton** — intervals.icu calendar → custom workouts on the chosen device platform.
+
+### Zone sync
+
+Reads FTP, LTHR, max HR, and power/HR zones from intervals.icu sport settings and writes them to the iGPSPORT profile (CLI only for now).

--- a/src/intervalssync/cli/main.py
+++ b/src/intervalssync/cli/main.py
@@ -20,6 +20,12 @@ from ..igpsport.core import SyncConfig as IgpSyncConfig
 from ..igpsport.core import SyncError as IgpSyncError
 from ..igpsport.core import SyncResult as IgpSyncResult
 from ..igpsport.core import sync as igpsport_sync
+from ..igpsport.profile_sync import (
+    ProfileSyncConfig,
+    ProfileSyncResult,
+    result_payload as profile_sync_result_payload,
+    sync_profile_zones,
+)
 from ..bryton.workout import (
     BrytonWorkoutUploadConfig,
     BrytonWorkoutUploadResult,
@@ -452,6 +458,59 @@ def cmd_upload_workouts(args: argparse.Namespace) -> int:
     return EXIT_OK if ok else EXIT_SYNC_ERROR
 
 
+def cmd_sync_zones(args: argparse.Namespace) -> int:
+    config = cli_config_module.load()
+    use_json = args.json
+
+    try:
+        env_path = resolve_env_path(
+            env_file=Path(args.env_file) if args.env_file else None,
+            config_env_file=config.env_file or None,
+        )
+        credentials = load_credentials(env_path, source="igpsport")
+    except CliConfigError as exc:
+        if use_json:
+            _emit_json({"ok": False, "source": "igpsport", "error": str(exc)})
+        else:
+            print(exc, file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    sync_config = ProfileSyncConfig(
+        igp_user=credentials.igp_user,
+        igp_password=credentials.igp_password,
+        intervals_api_key=credentials.intervals_api_key,
+        sport=args.sport,
+    )
+
+    def progress(message: str) -> None:
+        print(message, file=sys.stderr)
+
+    try:
+        result = sync_profile_zones(sync_config, progress=progress)
+    except IgpSyncError as exc:
+        if use_json:
+            _emit_json(profile_sync_result_payload(ProfileSyncResult(None, None), ok=False, error=str(exc)))
+        else:
+            print(f"✗ {exc}", file=sys.stderr)
+        return EXIT_SYNC_ERROR
+    except Exception as exc:  # noqa: BLE001
+        if use_json:
+            _emit_json(profile_sync_result_payload(ProfileSyncResult(None, None), ok=False, error=str(exc)))
+        else:
+            print(f"✗ Unexpected error: {exc}", file=sys.stderr)
+        return EXIT_SYNC_ERROR
+
+    if use_json:
+        _emit_json(profile_sync_result_payload(result, ok=True))
+    else:
+        summary = profile_sync_result_payload(result, ok=True)
+        print(
+            f"Done — FTP {summary.get('ftp')}, LTHR {summary.get('lthr')}, "
+            f"MHR {summary.get('mhr')} synced to iGPSPORT."
+        )
+    return EXIT_OK
+
+
 def _add_source_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--source",
@@ -542,6 +601,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Re-upload workouts even if already on the target device platform.",
     )
     upload_workouts_parser.set_defaults(func=cmd_upload_workouts)
+
+    sync_zones_parser = subparsers.add_parser(
+        "sync-zones",
+        parents=[common],
+        help="Push FTP, LTHR, max HR, and zones from intervals.icu to iGPSPORT.",
+    )
+    sync_zones_parser.add_argument(
+        "--sport",
+        default="Ride",
+        metavar="TYPE",
+        help='intervals.icu sport-settings key (default: "Ride").',
+    )
+    sync_zones_parser.set_defaults(func=cmd_sync_zones)
 
     return parser
 

--- a/src/intervalssync/gui/app.py
+++ b/src/intervalssync/gui/app.py
@@ -306,7 +306,7 @@ async def _app(page: ft.Page) -> None:
         notify_update(latest, quiet_when_current=True)
 
     async def auto_check_profile_sync() -> None:
-        if not config.enable_igpsport:
+        if not config.enable_igpsport or not config.profile_sync_check_on_launch:
             return
         await profile_sync_ui.prompt_if_needed(page, config, store)
 

--- a/src/intervalssync/gui/app.py
+++ b/src/intervalssync/gui/app.py
@@ -17,6 +17,7 @@ from . import secrets as secrets_module
 from .update_check import RELEASES_PAGE, check_for_update
 from .settings_view import build_settings_view
 from .sync_view import build_sync_view
+from . import profile_sync_ui
 from . import theme
 
 
@@ -228,6 +229,10 @@ async def _app(page: ft.Page) -> None:
     async def show_settings(_: ft.ControlEvent | None = None) -> None:
         nonlocal current_tab
         current_tab = _TAB_SETTINGS
+
+        async def on_profile_sync_check() -> None:
+            await profile_sync_ui.prompt_if_needed(page, config, store)
+
         body.content = _scrollable(
             await build_settings_view(
                 page,
@@ -236,6 +241,7 @@ async def _app(page: ft.Page) -> None:
                 on_saved=show_sync,
                 perms=perms,
                 apply_download_location=apply_download_location,
+                on_profile_sync_check=on_profile_sync_check,
             )
         )
         header_slot.content = _header()
@@ -299,7 +305,13 @@ async def _app(page: ft.Page) -> None:
         latest = await asyncio.to_thread(check_for_update, __version__)
         notify_update(latest, quiet_when_current=True)
 
+    async def auto_check_profile_sync() -> None:
+        if not config.enable_igpsport:
+            return
+        await profile_sync_ui.prompt_if_needed(page, config, store)
+
     page.run_task(auto_check_updates)
+    page.run_task(auto_check_profile_sync)
 
 
 def main() -> None:

--- a/src/intervalssync/gui/config.py
+++ b/src/intervalssync/gui/config.py
@@ -58,6 +58,8 @@ class AppConfig:
     workout_days_ahead: int = 1
     # intervals.icu threshold fingerprint the user declined to sync; cleared after sync.
     profile_sync_declined_fingerprint: str = ""
+    # Prompt on launch when FTP, LTHR, or max HR differ from intervals.icu.
+    profile_sync_check_on_launch: bool = True
 
 
 def any_source_enabled(config: AppConfig) -> bool:

--- a/src/intervalssync/gui/config.py
+++ b/src/intervalssync/gui/config.py
@@ -56,6 +56,8 @@ class AppConfig:
     uploaded_bryton_workouts: dict[str, str] = field(default_factory=dict)
     # How many calendar days of planned workouts to upload (1 = today only).
     workout_days_ahead: int = 1
+    # intervals.icu threshold fingerprint the user declined to sync; cleared after sync.
+    profile_sync_declined_fingerprint: str = ""
 
 
 def any_source_enabled(config: AppConfig) -> bool:

--- a/src/intervalssync/gui/profile_sync_ui.py
+++ b/src/intervalssync/gui/profile_sync_ui.py
@@ -1,0 +1,221 @@
+"""GUI helpers for iGPSPORT profile / zone sync."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable
+
+import flet as ft
+
+from ..igpsport.core import SyncError
+from ..igpsport.profile_sync import (
+    ProfileSyncConfig,
+    ProfileSyncResult,
+    ProfileThresholdStatus,
+    fetch_profile_threshold_status,
+    sync_profile_zones,
+)
+from . import config as config_module
+from . import secrets as secrets_module
+from . import theme
+
+
+async def credentials_ready(
+    config: config_module.AppConfig,
+    store: secrets_module.SecretStore,
+) -> tuple[str, str] | None:
+    if not config.enable_igpsport or not config.igp_user:
+        return None
+    igp_password = await store.get(secrets_module.IGP_PASSWORD)
+    api_key = await store.get(secrets_module.INTERVALS_API_KEY)
+    if not igp_password or not api_key:
+        return None
+    return igp_password, api_key
+
+
+def run_sync_profile_zones(
+    config: config_module.AppConfig,
+    igp_password: str,
+    api_key: str,
+    *,
+    progress: Callable[[str], None] | None = None,
+) -> ProfileSyncResult:
+    sync_config = ProfileSyncConfig(
+        igp_user=config.igp_user,
+        igp_password=igp_password,
+        intervals_api_key=api_key,
+    )
+    return sync_profile_zones(sync_config, progress=progress)
+
+
+async def check_profile_thresholds(
+    config: config_module.AppConfig,
+    store: secrets_module.SecretStore,
+) -> ProfileThresholdStatus | None:
+    creds = await credentials_ready(config, store)
+    if creds is None:
+        return None
+    igp_password, api_key = creds
+    try:
+        return await asyncio.to_thread(
+            fetch_profile_threshold_status,
+            ProfileSyncConfig(
+                igp_user=config.igp_user,
+                igp_password=igp_password,
+                intervals_api_key=api_key,
+            ),
+        )
+    except (SyncError, Exception):  # noqa: BLE001 — fail silent for background checks
+        return None
+
+
+def _should_prompt(
+    config: config_module.AppConfig,
+    status: ProfileThresholdStatus,
+) -> bool:
+    if not status.needs_sync:
+        return False
+    if (
+        config.profile_sync_declined_fingerprint
+        and status.intervals_fingerprint == config.profile_sync_declined_fingerprint
+    ):
+        return False
+    return True
+
+
+def _clear_declined_fingerprint(config: config_module.AppConfig) -> None:
+    if config.profile_sync_declined_fingerprint:
+        config.profile_sync_declined_fingerprint = ""
+        config_module.save(config)
+
+
+def _save_declined_fingerprint(
+    config: config_module.AppConfig,
+    status: ProfileThresholdStatus,
+) -> None:
+    config.profile_sync_declined_fingerprint = status.intervals_fingerprint
+    config_module.save(config)
+
+
+def _sync_success_message(result: ProfileSyncResult) -> str:
+    if result.after is None:
+        return "iGPSPORT profile updated."
+    member = result.after.get("member")
+    if not isinstance(member, dict):
+        return "iGPSPORT profile updated."
+    parts: list[str] = []
+    for key, label in (("ftp", "FTP"), ("lthr", "LTHR"), ("mhr", "max HR")):
+        if key in member:
+            parts.append(f"{label} {member[key]}")
+    if parts:
+        return "iGPSPORT profile updated — " + ", ".join(parts) + "."
+    return "iGPSPORT profile updated."
+
+
+async def sync_with_feedback(
+    page: ft.Page,
+    config: config_module.AppConfig,
+    store: secrets_module.SecretStore,
+    *,
+    clear_declined: bool = True,
+) -> bool:
+    creds = await credentials_ready(config, store)
+    if creds is None:
+        page.show_dialog(
+            ft.SnackBar(
+                ft.Text("Add iGPSPORT credentials and intervals.icu API key in Settings first.")
+            )
+        )
+        page.update()
+        return False
+
+    igp_password, api_key = creds
+    page.show_dialog(ft.SnackBar(ft.Text("Updating iGPSPORT profile…")))
+    page.update()
+
+    def _run_sync() -> tuple[bool, str]:
+        try:
+            result = run_sync_profile_zones(config, igp_password, api_key)
+            return True, _sync_success_message(result)
+        except SyncError as exc:
+            return False, str(exc)
+        except Exception as exc:  # noqa: BLE001 — surface any failure to the user
+            return False, f"Unexpected error: {exc}"
+
+    ok, message = await asyncio.to_thread(_run_sync)
+    if ok and clear_declined:
+        _clear_declined_fingerprint(config)
+    page.show_dialog(ft.SnackBar(ft.Text(message)))
+    page.update()
+    return ok
+
+
+async def prompt_if_needed(
+    page: ft.Page,
+    config: config_module.AppConfig,
+    store: secrets_module.SecretStore,
+) -> None:
+    if not config.enable_igpsport:
+        return
+
+    status = await check_profile_thresholds(config, store)
+    if status is None or not _should_prompt(config, status):
+        return
+
+    colors = theme.palette(page)
+
+    async def dismiss(_: ft.ControlEvent) -> None:
+        page.pop_dialog()
+        _save_declined_fingerprint(config, status)
+        page.update()
+
+    async def update_now(_: ft.ControlEvent) -> None:
+        page.pop_dialog()
+        page.update()
+        await sync_with_feedback(page, config, store)
+
+    difference_lines = [
+        ft.Text(f"• {diff}", size=13, color=colors["text"])
+        for diff in status.differences
+    ]
+    page.show_dialog(
+        ft.AlertDialog(
+            modal=True,
+            shape=ft.RoundedRectangleBorder(radius=theme.RADIUS_MD),
+            title=theme.display_text("Update iGPSPORT profile?", size=20),
+            content=ft.Column(
+                tight=True,
+                spacing=theme.SPACE_SM,
+                controls=[
+                    ft.Text(
+                        "Your iGPSPORT thresholds differ from intervals.icu:",
+                        size=13,
+                        color=colors["text_muted"],
+                    ),
+                    *difference_lines,
+                    ft.Text(
+                        "Power and heart-rate zones will be updated too.",
+                        size=12,
+                        color=colors["text_muted"],
+                    ),
+                ],
+            ),
+            actions=[
+                ft.TextButton("Not now", on_click=dismiss),
+                ft.TextButton("Update now", on_click=update_now),
+            ],
+        )
+    )
+    page.update()
+
+
+def format_threshold_status(status: ProfileThresholdStatus | None) -> str:
+    if status is None:
+        return "Could not check profile status."
+    if not status.needs_sync:
+        return "In sync with intervals.icu."
+    if len(status.differences) == 1:
+        return f"Out of sync: {status.differences[0]}"
+    return "Out of sync: " + ", ".join(
+        diff.split(":")[0] for diff in status.differences
+    )

--- a/src/intervalssync/gui/settings_view.py
+++ b/src/intervalssync/gui/settings_view.py
@@ -320,6 +320,24 @@ async def build_settings_view(
         "Checking…",
         size=12,
         color=colors["text_muted"],
+        max_lines=2,
+        no_wrap=False,
+        overflow=ft.TextOverflow.ELLIPSIS,
+    )
+    profile_sync_hint = ft.Text(
+        "Add iGPSPORT credentials and intervals.icu API key first.",
+        size=12,
+        color=colors["text_muted"],
+        visible=False,
+    )
+    profile_sync_message_area = ft.Container(
+        height=34,
+        content=ft.Column(
+            tight=True,
+            spacing=0,
+            controls=[profile_sync_status, profile_sync_hint],
+        ),
+        alignment=ft.Alignment.TOP_LEFT,
     )
     profile_sync_button = ft.OutlinedButton(
         "Sync profile now",
@@ -328,23 +346,32 @@ async def build_settings_view(
             shape=ft.RoundedRectangleBorder(radius=theme.RADIUS_SM),
         ),
     )
-    profile_sync_hint = ft.Text(
-        "Add iGPSPORT credentials and intervals.icu API key first.",
-        size=12,
-        color=colors["text_muted"],
-        visible=False,
+    profile_sync_check_on_launch = ft.Switch(
+        label="Check on app launch",
+        value=config.profile_sync_check_on_launch,
+        active_color=colors["accent"],
+    )
+    profile_sync_actions = ft.Row(
+        spacing=theme.SPACE_MD,
+        alignment=ft.MainAxisAlignment.CENTER,
+        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        controls=[
+            profile_sync_button,
+            profile_sync_check_on_launch,
+        ],
     )
 
     async def refresh_profile_sync_status() -> None:
         creds = await profile_sync_ui.credentials_ready(config, store)
         if creds is None:
-            profile_sync_status.value = "Sign in to check profile status."
-            profile_sync_button.disabled = True
+            profile_sync_status.visible = False
             profile_sync_hint.visible = True
+            profile_sync_button.disabled = True
             page.update()
             return
 
         profile_sync_hint.visible = False
+        profile_sync_status.visible = True
         profile_sync_button.disabled = False
         profile_sync_status.value = "Checking…"
         page.update()
@@ -378,11 +405,11 @@ async def build_settings_view(
             ft.Container(
                 padding=ft.Padding(theme.SPACE_MD, 0, theme.SPACE_MD, theme.SPACE_SM),
                 content=ft.Column(
-                    spacing=theme.SPACE_SM,
+                    tight=True,
+                    spacing=theme.SPACE_XS,
                     controls=[
-                        profile_sync_status,
-                        profile_sync_button,
-                        profile_sync_hint,
+                        profile_sync_message_area,
+                        profile_sync_actions,
                     ],
                 ),
             )
@@ -527,6 +554,7 @@ async def build_settings_view(
             workout_days_ahead.value = "1"
         config.delete_after_upload = delete_after_upload.value
         config.force_resync = force_resync.value
+        config.profile_sync_check_on_launch = bool(profile_sync_check_on_launch.value)
         config.activity_type = activity_type.value or ""
         config.dropbox_folder = dropbox_folder.value.strip() or DEFAULT_DROPBOX_FOLDER
         config.dropbox_date_filenames = bool(dropbox_date_filenames_switch.value)

--- a/src/intervalssync/gui/settings_view.py
+++ b/src/intervalssync/gui/settings_view.py
@@ -17,6 +17,7 @@ from ..dropbox_client import (
     start_dropbox_auth,
 )
 from . import theme
+from . import profile_sync_ui
 from .system import open_folder
 
 
@@ -37,6 +38,7 @@ async def build_settings_view(
     on_saved: Callable[[], Awaitable[None]],
     perms: PermissionHandler | None = None,
     apply_download_location: Callable[[], Awaitable[None]] | None = None,
+    on_profile_sync_check: Callable[[], Awaitable[None]] | None = None,
 ) -> ft.Control:
     colors = theme.palette(page)
 
@@ -314,6 +316,79 @@ async def build_settings_view(
         ],
     )
 
+    profile_sync_status = ft.Text(
+        "Checking…",
+        size=12,
+        color=colors["text_muted"],
+    )
+    profile_sync_button = ft.OutlinedButton(
+        "Sync profile now",
+        icon=ft.Icons.SYNC,
+        style=ft.ButtonStyle(
+            shape=ft.RoundedRectangleBorder(radius=theme.RADIUS_SM),
+        ),
+    )
+    profile_sync_hint = ft.Text(
+        "Add iGPSPORT credentials and intervals.icu API key first.",
+        size=12,
+        color=colors["text_muted"],
+        visible=False,
+    )
+
+    async def refresh_profile_sync_status() -> None:
+        creds = await profile_sync_ui.credentials_ready(config, store)
+        if creds is None:
+            profile_sync_status.value = "Sign in to check profile status."
+            profile_sync_button.disabled = True
+            profile_sync_hint.visible = True
+            page.update()
+            return
+
+        profile_sync_hint.visible = False
+        profile_sync_button.disabled = False
+        profile_sync_status.value = "Checking…"
+        page.update()
+        status = await profile_sync_ui.check_profile_thresholds(config, store)
+        profile_sync_status.value = profile_sync_ui.format_threshold_status(status)
+        page.update()
+
+    async def on_profile_sync_click(_: ft.ControlEvent) -> None:
+        profile_sync_button.disabled = True
+        page.update()
+        await profile_sync_ui.sync_with_feedback(page, config, store)
+        await refresh_profile_sync_status()
+
+    profile_sync_button.on_click = on_profile_sync_click
+
+    async def on_profile_tile_change(e: ft.ControlEvent) -> None:
+        if e.control.expanded:
+            await refresh_profile_sync_status()
+
+    profile_sync_options = ft.ExpansionTile(
+        title=ft.Text("iGPSPORT profile", weight=ft.FontWeight.W_500),
+        subtitle=ft.Text(
+            "FTP, LTHR, max HR, and zones from intervals.icu",
+            size=12,
+            color=colors["text_muted"],
+        ),
+        leading=ft.Icon(ft.Icons.MONITOR_HEART_OUTLINED, color=colors["accent"]),
+        affinity=ft.TileAffinity.LEADING,
+        on_change=on_profile_tile_change,
+        controls=[
+            ft.Container(
+                padding=ft.Padding(theme.SPACE_MD, 0, theme.SPACE_MD, theme.SPACE_SM),
+                content=ft.Column(
+                    spacing=theme.SPACE_SM,
+                    controls=[
+                        profile_sync_status,
+                        profile_sync_button,
+                        profile_sync_hint,
+                    ],
+                ),
+            )
+        ],
+    )
+
     save_to_downloads = ft.Switch(
         label="Save to phone's Downloads folder",
         value=config.save_to_downloads,
@@ -385,11 +460,16 @@ async def build_settings_view(
         visible=config.enable_igpsport or config.enable_bryton,
         content=dropbox_options,
     )
+    profile_sync_section = ft.Container(
+        visible=config.enable_igpsport,
+        content=profile_sync_options,
+    )
 
     def update_source_visibility(_: ft.ControlEvent | None = None) -> None:
         igp_credentials.visible = bool(enable_igpsport.value)
         workout_sync_section.visible = bool(enable_igpsport.value or enable_bryton.value)
         dropbox_section.visible = bool(enable_igpsport.value or enable_bryton.value)
+        profile_sync_section.visible = bool(enable_igpsport.value)
         bryton_credentials.visible = bool(enable_bryton.value)
         page.update()
 
@@ -491,6 +571,8 @@ async def build_settings_view(
 
         page.show_dialog(ft.SnackBar(ft.Text(message)))
         await on_saved()
+        if on_profile_sync_check is not None and config.enable_igpsport:
+            await on_profile_sync_check()
 
     save_button = ft.FilledButton(
         content=ft.Row(
@@ -541,6 +623,7 @@ async def build_settings_view(
                 force_resync,
                 workout_sync_section,
             ),
+            profile_sync_section,
             theme.settings_section(
                 page,
                 "Storage",

--- a/src/intervalssync/igpsport/interval_info.py
+++ b/src/intervalssync/igpsport/interval_info.py
@@ -1,0 +1,151 @@
+"""iGPSPORT mobile API for personal interval / zone profile."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import requests
+
+IGPS_MOBILE_API = "https://prod.en.igpsport.com/service/mobile/api"
+GET_INTERVAL_URL = f"{IGPS_MOBILE_API}/v2/User/UserIntervalInfo"
+UPDATE_INTERVAL_URL = f"{IGPS_MOBILE_API}/User/UpdatePersonalIntervalInfo"
+
+# iGPSPORT heartRateComputeMode: 0 = max HR, 1 = HRR, 2 = LTHR.
+HEART_RATE_COMPUTE_MODE_MAX_HR = 0
+
+
+def member_id_from_token(auth_headers: dict[str, str]) -> int | None:
+    token = auth_headers.get("Authorization", "").removeprefix("Bearer ").strip()
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    segment = parts[1]
+    padding = "=" * (-len(segment) % 4)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(segment + padding))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    for key in ("memberid", "memberId", "sub"):
+        value = payload.get(key)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def mobile_headers(auth_headers: dict[str, str], member_id: int | None) -> dict[str, str]:
+    headers = {
+        **auth_headers,
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Accept-Language": "en",
+        "Content-Type": "application/json; charset=UTF-8",
+        "User-Agent": "intervalssync/1.0",
+        "qiwu-app-version": "8.06.36",
+        "timezone": "UTC",
+    }
+    if member_id is not None:
+        headers["qiwu-uid"] = str(member_id)
+    return headers
+
+
+def _unwrap_api_data(response_json: Any) -> dict[str, Any] | None:
+    if not isinstance(response_json, dict):
+        return None
+    if response_json.get("code") != 0:
+        return None
+    data = response_json.get("data")
+    if isinstance(data, dict) and "member" in data:
+        return data
+    if isinstance(data, dict):
+        nested = data.get("data")
+        if isinstance(nested, dict) and "member" in nested:
+            return nested
+        for key in ("intervalInfo", "userIntervalInfo", "personalIntervalInfo"):
+            nested = data.get(key)
+            if isinstance(nested, dict) and "member" in nested:
+                return nested
+    if "member" in response_json:
+        return response_json
+    return None
+
+
+def fetch_personal_interval_info(
+    session: requests.Session,
+    headers: dict[str, str],
+) -> dict[str, Any]:
+    """GET v2/User/UserIntervalInfo."""
+    get_headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+    try:
+        resp = session.get(GET_INTERVAL_URL, headers=get_headers, timeout=30)
+    except requests.RequestException as exc:
+        raise RuntimeError(f"GET UserIntervalInfo failed: {exc}") from exc
+
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"GET UserIntervalInfo: HTTP {resp.status_code}, non-JSON body"
+        ) from exc
+
+    payload = _unwrap_api_data(body)
+    if payload is None:
+        raise RuntimeError(
+            f"GET UserIntervalInfo: HTTP {resp.status_code}, "
+            f"code={body.get('code') if isinstance(body, dict) else '?'}, "
+            f"no member block in response"
+        )
+    return payload
+
+
+def update_personal_interval_info(
+    session: requests.Session,
+    headers: dict[str, str],
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    """POST UpdatePersonalIntervalInfo."""
+    try:
+        resp = session.post(UPDATE_INTERVAL_URL, headers=headers, json=body, timeout=30)
+    except requests.RequestException as exc:
+        raise RuntimeError(f"POST UpdatePersonalIntervalInfo failed: {exc}") from exc
+
+    try:
+        result = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"POST UpdatePersonalIntervalInfo: HTTP {resp.status_code}, non-JSON body"
+        ) from exc
+
+    if not resp.ok:
+        raise RuntimeError(f"POST UpdatePersonalIntervalInfo: HTTP {resp.status_code}")
+
+    if isinstance(result, dict) and result.get("code") not in (0, None):
+        message = result.get("message") or "unknown error"
+        raise RuntimeError(f"POST UpdatePersonalIntervalInfo failed: {message}")
+
+    return result if isinstance(result, dict) else {}
+
+
+def zone_range_summary(zones: list[dict[str, Any]]) -> str:
+    if not zones:
+        return "(none)"
+    return " | ".join(f"{z.get('start')}-{z.get('end')}" for z in zones)
+
+
+def profile_summary(body: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact summary dict for CLI JSON output."""
+    member = body.get("member") if isinstance(body.get("member"), dict) else {}
+    power = body.get("power") if isinstance(body.get("power"), list) else []
+    heart_rate = body.get("heartRate") if isinstance(body.get("heartRate"), list) else []
+    return {
+        "ftp": member.get("ftp"),
+        "lthr": member.get("lthr"),
+        "mhr": member.get("mhr"),
+        "heart_rate_compute_mode": member.get("heartRateComputeMode"),
+        "power_zones": zone_range_summary(power),
+        "hr_zones": zone_range_summary(heart_rate),
+    }

--- a/src/intervalssync/igpsport/profile_sync.py
+++ b/src/intervalssync/igpsport/profile_sync.py
@@ -1,0 +1,173 @@
+"""Sync thresholds and zones from intervals.icu to iGPSPORT profile."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import requests
+
+from .. import intervals_icu
+from ..intervals_icu import SportSettings
+from .core import SyncError, login
+from .interval_info import (
+    HEART_RATE_COMPUTE_MODE_MAX_HR,
+    fetch_personal_interval_info,
+    mobile_headers,
+    member_id_from_token,
+    profile_summary,
+    update_personal_interval_info,
+    zone_range_summary,
+)
+from .zone_map import map_hr_zones, map_power_zones
+
+Progress = Callable[[str], None]
+
+
+def _noop(_message: str) -> None:
+    pass
+
+
+@dataclass
+class ProfileSyncConfig:
+    igp_user: str
+    igp_password: str
+    intervals_api_key: str
+    sport: str = "Ride"
+
+
+@dataclass
+class ProfileSyncResult:
+    before: dict[str, Any] | None
+    after: dict[str, Any] | None
+
+
+def _validate_sport_settings(settings: SportSettings) -> None:
+    if settings.ftp is None or settings.ftp <= 0:
+        raise SyncError("intervals.icu sport settings missing FTP")
+    if settings.max_hr is None or settings.max_hr <= 0:
+        raise SyncError("intervals.icu sport settings missing max HR")
+    if not settings.power_zones:
+        raise SyncError("intervals.icu sport settings missing power zones")
+    if not settings.hr_zones:
+        raise SyncError("intervals.icu sport settings missing HR zones")
+
+
+def apply_intervals_settings(
+    body: dict[str, Any],
+    settings: SportSettings,
+) -> dict[str, Any]:
+    """Return a copy of the iGPSPORT payload with thresholds and zones updated."""
+    updated = copy.deepcopy(body)
+    member = updated.get("member")
+    if not isinstance(member, dict):
+        raise SyncError("iGPSPORT profile payload has no member block")
+
+    ftp = int(round(settings.ftp or 0))
+    max_hr = int(round(settings.max_hr or 0))
+    lthr = int(round(settings.lthr or 0)) if settings.lthr is not None else member.get("lthr")
+
+    member["ftp"] = ftp
+    member["mhr"] = max_hr
+    if lthr is not None:
+        member["lthr"] = lthr
+    member["heartRateComputeMode"] = HEART_RATE_COMPUTE_MODE_MAX_HR
+
+    power = updated.get("power")
+    if isinstance(power, list) and power:
+        updated["power"] = map_power_zones(settings.power_zones, float(ftp), power)
+
+    heart_rate = updated.get("heartRate")
+    if isinstance(heart_rate, list) and heart_rate:
+        updated["heartRate"] = map_hr_zones(settings.hr_zones, float(max_hr), heart_rate)
+
+    return updated
+
+
+def _report_summary(report: Progress, label: str, body: dict[str, Any]) -> None:
+    member = body.get("member") if isinstance(body.get("member"), dict) else {}
+    power = body.get("power") if isinstance(body.get("power"), list) else []
+    heart_rate = body.get("heartRate") if isinstance(body.get("heartRate"), list) else []
+    report(f"{label}:")
+    report(
+        "  member: "
+        + ", ".join(
+            f"{key}={member[key]}"
+            for key in ("ftp", "mhr", "lthr", "heartRateComputeMode", "quietHeartRate")
+            if key in member
+        )
+    )
+    report(f"  power:  {zone_range_summary(power)}")
+    report(f"  heartRate: {zone_range_summary(heart_rate)}")
+
+
+def sync_profile_zones(
+    config: ProfileSyncConfig,
+    progress: Progress | None = None,
+) -> ProfileSyncResult:
+    """Fetch intervals.icu sport settings and push them to iGPSPORT."""
+    report = progress or _noop
+
+    session = requests.Session()
+    report("Logging in to iGPSPORT…")
+    try:
+        auth_headers = login(session, config.igp_user, config.igp_password)
+    except Exception as exc:
+        raise SyncError(str(exc)) from exc
+
+    member_id = member_id_from_token(auth_headers)
+    headers = mobile_headers(auth_headers, member_id)
+
+    report("Fetching sport settings from intervals.icu…")
+    try:
+        settings = intervals_icu.fetch_sport_settings(
+            config.intervals_api_key,
+            config.sport,
+            http=session,
+        )
+    except requests.RequestException as exc:
+        raise SyncError(f"Could not fetch intervals.icu sport settings: {exc}") from exc
+
+    _validate_sport_settings(settings)
+
+    report("Fetching iGPSPORT profile…")
+    try:
+        current = fetch_personal_interval_info(session, headers)
+    except RuntimeError as exc:
+        raise SyncError(str(exc)) from exc
+
+    updated = apply_intervals_settings(current, settings)
+    _report_summary(report, "Before", current)
+    _report_summary(report, "After", updated)
+
+    report("Updating iGPSPORT profile…")
+    try:
+        update_personal_interval_info(session, headers, updated)
+    except RuntimeError as exc:
+        raise SyncError(str(exc)) from exc
+
+    report("Verifying iGPSPORT profile…")
+    try:
+        after = fetch_personal_interval_info(session, headers)
+    except RuntimeError as exc:
+        raise SyncError(str(exc)) from exc
+
+    _report_summary(report, "Read-back", after)
+    return ProfileSyncResult(before=current, after=after)
+
+
+def result_payload(result: ProfileSyncResult, *, ok: bool, error: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "ok": ok,
+        "source": "igpsport",
+    }
+    if result.before is not None:
+        payload["before"] = profile_summary(result.before)
+    if result.after is not None:
+        summary = profile_summary(result.after)
+        payload.update(summary)
+        payload["after"] = summary
+    if error is not None:
+        payload["error"] = error
+    return payload

--- a/src/intervalssync/igpsport/profile_sync.py
+++ b/src/intervalssync/igpsport/profile_sync.py
@@ -43,6 +43,83 @@ class ProfileSyncResult:
     after: dict[str, Any] | None
 
 
+@dataclass
+class ProfileThresholdStatus:
+    needs_sync: bool
+    differences: list[str]
+    intervals_fingerprint: str
+    intervals: dict[str, int | None]
+    igpsport: dict[str, int | None]
+
+
+_THRESHOLD_LABELS = {"ftp": "FTP", "lthr": "LTHR", "mhr": "max HR"}
+
+
+def _threshold_values(member: dict[str, Any]) -> dict[str, int | None]:
+    def _int_val(key: str) -> int | None:
+        value = member.get(key)
+        if value is None:
+            return None
+        try:
+            return int(round(float(value)))
+        except (TypeError, ValueError):
+            return None
+
+    return {
+        "ftp": _int_val("ftp"),
+        "lthr": _int_val("lthr"),
+        "mhr": _int_val("mhr"),
+    }
+
+
+def _threshold_fingerprint(settings: SportSettings) -> str:
+    ftp = int(round(settings.ftp or 0))
+    mhr = int(round(settings.max_hr or 0))
+    lthr = int(round(settings.lthr)) if settings.lthr is not None else ""
+    return f"{ftp}|{lthr}|{mhr}"
+
+
+def _intervals_threshold_values(settings: SportSettings) -> dict[str, int | None]:
+    return {
+        "ftp": int(round(settings.ftp or 0)),
+        "lthr": int(round(settings.lthr)) if settings.lthr is not None else None,
+        "mhr": int(round(settings.max_hr or 0)),
+    }
+
+
+def compare_profile_thresholds(
+    current: dict[str, Any],
+    settings: SportSettings,
+) -> ProfileThresholdStatus:
+    """Return whether FTP, LTHR, or max HR would change on sync."""
+    desired = apply_intervals_settings(current, settings)
+    member = current.get("member")
+    desired_member = desired.get("member")
+    current_vals = _threshold_values(member if isinstance(member, dict) else {})
+    desired_vals = _threshold_values(desired_member if isinstance(desired_member, dict) else {})
+
+    keys_to_compare = ["ftp", "mhr"]
+    if settings.lthr is not None:
+        keys_to_compare.append("lthr")
+
+    differences: list[str] = []
+    for key in keys_to_compare:
+        if current_vals.get(key) != desired_vals.get(key):
+            label = _THRESHOLD_LABELS[key]
+            differences.append(
+                f"{label}: iGPSPORT {current_vals.get(key)} "
+                f"→ intervals.icu {desired_vals.get(key)}"
+            )
+
+    return ProfileThresholdStatus(
+        needs_sync=bool(differences),
+        differences=differences,
+        intervals_fingerprint=_threshold_fingerprint(settings),
+        intervals=_intervals_threshold_values(settings),
+        igpsport=current_vals,
+    )
+
+
 def _validate_sport_settings(settings: SportSettings) -> None:
     if settings.ftp is None or settings.ftp <= 0:
         raise SyncError("intervals.icu sport settings missing FTP")
@@ -155,6 +232,36 @@ def sync_profile_zones(
 
     _report_summary(report, "Read-back", after)
     return ProfileSyncResult(before=current, after=after)
+
+
+def fetch_profile_threshold_status(config: ProfileSyncConfig) -> ProfileThresholdStatus:
+    """Compare iGPSPORT profile thresholds with intervals.icu sport settings."""
+    session = requests.Session()
+    try:
+        auth_headers = login(session, config.igp_user, config.igp_password)
+    except Exception as exc:
+        raise SyncError(str(exc)) from exc
+
+    member_id = member_id_from_token(auth_headers)
+    headers = mobile_headers(auth_headers, member_id)
+
+    try:
+        settings = intervals_icu.fetch_sport_settings(
+            config.intervals_api_key,
+            config.sport,
+            http=session,
+        )
+    except requests.RequestException as exc:
+        raise SyncError(f"Could not fetch intervals.icu sport settings: {exc}") from exc
+
+    _validate_sport_settings(settings)
+
+    try:
+        current = fetch_personal_interval_info(session, headers)
+    except RuntimeError as exc:
+        raise SyncError(str(exc)) from exc
+
+    return compare_profile_thresholds(current, settings)
 
 
 def result_payload(result: ProfileSyncResult, *, ok: bool, error: str | None = None) -> dict[str, Any]:

--- a/src/intervalssync/igpsport/zone_map.py
+++ b/src/intervalssync/igpsport/zone_map.py
@@ -1,0 +1,126 @@
+"""Map intervals.icu zone definitions onto iGPSPORT fixed zone slots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+POWER_ZONE_CAP = 1999
+
+
+def power_upper_bounds_watts(power_zones_pct: list[float], ftp: float) -> list[int]:
+    """Convert intervals % FTP upper bounds to absolute watt boundaries."""
+    if ftp <= 0 or not power_zones_pct:
+        return []
+    bounds = [int(round(ftp * pct / 100)) for pct in power_zones_pct]
+    bounds[-1] = min(bounds[-1], POWER_ZONE_CAP)
+    return bounds
+
+
+def hr_upper_bounds_bpm(hr_zones_bpm: list[float], max_hr: float) -> list[int]:
+    """Return intervals HR zone upper bounds capped at max_hr."""
+    if max_hr <= 0 or not hr_zones_bpm:
+        return []
+    cap = int(round(max_hr))
+    bounds = [int(round(bpm)) for bpm in hr_zones_bpm]
+    bounds[-1] = min(bounds[-1], cap)
+    return bounds
+
+
+def _prepare_intervals_ends(intervals_ends: list[int], slot_count: int, cap: int) -> list[int]:
+    """Drop open-ended last intervals bound when extra iGPSPORT slots need the cap."""
+    ends = list(intervals_ends)
+    n = len(ends)
+    p = slot_count
+    pad_count = p - n
+    if pad_count > 0 and n >= 2 and ends[-1] >= cap - pad_count:
+        ends = ends[:-1]
+    return ends
+
+
+def _enforce_strictly_increasing(ends: list[int], cap: int) -> list[int]:
+    """Ensure zone end values strictly increase and the last is capped."""
+    if not ends:
+        return ends
+    out = [int(value) for value in ends]
+    for index in range(1, len(out)):
+        if out[index] <= out[index - 1]:
+            out[index] = out[index - 1] + 1
+    out[-1] = min(out[-1], cap)
+    if len(out) > 1 and out[-1] <= out[-2]:
+        index = len(out) - 2
+        while index > 0 and out[index] >= out[index + 1]:
+            out[index] = out[index + 1] - 1
+            index -= 1
+        if out[0] >= out[1]:
+            out[0] = max(0, out[1] - 1)
+    return out
+
+
+def _slot_end_values(intervals_ends: list[int], slot_count: int, cap: int) -> list[int]:
+    """Map intervals zone count onto a fixed iGPSPORT slot count."""
+    if slot_count <= 0:
+        return []
+    if not intervals_ends:
+        return list(range(cap, cap - slot_count, -1))
+
+    ends = _prepare_intervals_ends(intervals_ends, slot_count, cap)
+    n = len(ends)
+    p = slot_count
+    pad_count = p - n
+
+    if n == p:
+        result = list(ends)
+    elif n < p:
+        result = list(ends)
+        for index in range(pad_count):
+            result.append(cap - pad_count + 1 + index)
+    else:
+        result = list(ends[: p - 1])
+        result.append(ends[-1])
+
+    return _enforce_strictly_increasing(result, cap)
+
+
+def _apply_end_values(
+    end_values: list[int],
+    igpsport_zones: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Rewrite start/end on iGPSPORT zone dicts, preserving other fields."""
+    out: list[dict[str, Any]] = []
+    start = 0
+    for index, zone in enumerate(igpsport_zones):
+        if not isinstance(zone, dict):
+            continue
+        updated = dict(zone)
+        updated["start"] = start
+        updated["end"] = end_values[index]
+        start = end_values[index]
+        out.append(updated)
+    return out
+
+
+def map_power_zones(
+    intervals_pct: list[float],
+    ftp: float,
+    igpsport_zones: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Map intervals.icu power zones onto iGPSPORT power slots."""
+    if not igpsport_zones:
+        return []
+    intervals_ends = power_upper_bounds_watts(intervals_pct, ftp)
+    slot_ends = _slot_end_values(intervals_ends, len(igpsport_zones), POWER_ZONE_CAP)
+    return _apply_end_values(slot_ends, igpsport_zones)
+
+
+def map_hr_zones(
+    intervals_bpm: list[float],
+    max_hr: float,
+    igpsport_zones: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Map intervals.icu HR zones onto iGPSPORT heart-rate slots."""
+    if not igpsport_zones:
+        return []
+    cap = int(round(max_hr))
+    intervals_ends = hr_upper_bounds_bpm(intervals_bpm, max_hr)
+    slot_ends = _slot_end_values(intervals_ends, len(igpsport_zones), cap)
+    return _apply_end_values(slot_ends, igpsport_zones)

--- a/src/intervalssync/igpsport/zone_map.py
+++ b/src/intervalssync/igpsport/zone_map.py
@@ -4,16 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-POWER_ZONE_CAP = 1999
+POWER_INTERIOR_CAP = 1999
+POWER_LAST_ZONE_END = 2500
 
 
 def power_upper_bounds_watts(power_zones_pct: list[float], ftp: float) -> list[int]:
     """Convert intervals % FTP upper bounds to absolute watt boundaries."""
     if ftp <= 0 or not power_zones_pct:
         return []
-    bounds = [int(round(ftp * pct / 100)) for pct in power_zones_pct]
-    bounds[-1] = min(bounds[-1], POWER_ZONE_CAP)
-    return bounds
+    return [int(round(ftp * pct / 100)) for pct in power_zones_pct]
 
 
 def hr_upper_bounds_bpm(hr_zones_bpm: list[float], max_hr: float) -> list[int]:
@@ -108,7 +107,14 @@ def map_power_zones(
     if not igpsport_zones:
         return []
     intervals_ends = power_upper_bounds_watts(intervals_pct, ftp)
-    slot_ends = _slot_end_values(intervals_ends, len(igpsport_zones), POWER_ZONE_CAP)
+    slot_count = len(igpsport_zones)
+    if slot_count == 1:
+        slot_ends = [POWER_LAST_ZONE_END]
+    else:
+        interior = _slot_end_values(intervals_ends, slot_count - 1, POWER_INTERIOR_CAP)
+        interior[-1] = min(interior[-1], POWER_INTERIOR_CAP)
+        interior = _enforce_strictly_increasing(interior, POWER_INTERIOR_CAP)
+        slot_ends = interior + [POWER_LAST_ZONE_END]
     return _apply_end_values(slot_ends, igpsport_zones)
 
 

--- a/src/intervalssync/intervals_icu.py
+++ b/src/intervalssync/intervals_icu.py
@@ -28,6 +28,15 @@ class CalendarWorkout:
     workout_doc: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class SportSettings:
+    ftp: float | None
+    lthr: float | None
+    max_hr: float | None
+    power_zones: list[float]
+    hr_zones: list[float]
+
+
 def _num(value: Any) -> float | None:
     if value is None:
         return None
@@ -35,6 +44,17 @@ def _num(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _num_list(value: Any) -> list[float]:
+    if not isinstance(value, list):
+        return []
+    out: list[float] = []
+    for item in value:
+        num = _num(item)
+        if num is not None:
+            out.append(num)
+    return out
 
 
 def upload_fit_file(
@@ -121,13 +141,13 @@ def fetch_calendar_workouts(
     return workouts
 
 
-def fetch_sport_settings_max_hr(
+def fetch_sport_settings(
     api_key: str,
-    sport: str,
+    sport: str = "Ride",
     *,
     http: requests.Session | None = None,
-) -> float | None:
-    """Return athlete max HR (bpm) from intervals.icu sport settings."""
+) -> SportSettings:
+    """Return athlete thresholds and zone definitions from intervals.icu sport settings."""
     client = http or requests.Session()
     resp = client.get(
         f"{INTERVALS_SPORT_SETTINGS_URL}/{sport}",
@@ -137,5 +157,21 @@ def fetch_sport_settings_max_hr(
     resp.raise_for_status()
     data = resp.json()
     if not isinstance(data, dict):
-        return None
-    return _num(data.get("max_hr"))
+        return SportSettings(None, None, None, [], [])
+    return SportSettings(
+        ftp=_num(data.get("ftp")),
+        lthr=_num(data.get("lthr")),
+        max_hr=_num(data.get("max_hr")),
+        power_zones=_num_list(data.get("power_zones")),
+        hr_zones=_num_list(data.get("hr_zones")),
+    )
+
+
+def fetch_sport_settings_max_hr(
+    api_key: str,
+    sport: str,
+    *,
+    http: requests.Session | None = None,
+) -> float | None:
+    """Return athlete max HR (bpm) from intervals.icu sport settings."""
+    return fetch_sport_settings(api_key, sport, http=http).max_hr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -299,3 +299,63 @@ def test_upload_workouts_bryton_json_sync_error(tmp_path: Path, monkeypatch, cap
     assert payload["ok"] is False
     assert payload["source"] == "bryton"
     assert payload["error"] == "bryton fetch failed"
+
+
+def test_sync_zones_parser_accepts_flags():
+    args = cli._build_parser().parse_args(["sync-zones", "--sport", "Ride", "--json"])
+    assert args.command == "sync-zones"
+    assert args.sport == "Ride"
+    assert args.json is True
+
+
+def test_sync_zones_json_success(tmp_path: Path, monkeypatch, capsys):
+    from intervalssync.igpsport import profile_sync as igp_profile_sync
+
+    env_file = tmp_path / ".env"
+    _write_env(env_file)
+
+    def fake_sync(config, progress=None):
+        if progress:
+            progress("syncing zones")
+        return igp_profile_sync.ProfileSyncResult(
+            before={"member": {"ftp": 240, "mhr": 190, "lthr": 150}},
+            after={
+                "member": {"ftp": 242, "mhr": 193, "lthr": 176},
+                "power": [{"start": 0, "end": 133}],
+                "heartRate": [{"start": 0, "end": 120}],
+            },
+        )
+
+    monkeypatch.setattr(cli, "sync_profile_zones", fake_sync)
+
+    args = cli._build_parser().parse_args(
+        ["sync-zones", "--env-file", str(env_file), "--json"]
+    )
+    assert cli.cmd_sync_zones(args) == cli.EXIT_OK
+
+    captured = capsys.readouterr()
+    assert "syncing zones" in captured.err
+    payload = json.loads(captured.out)
+    assert payload["ok"] is True
+    assert payload["source"] == "igpsport"
+    assert payload["ftp"] == 242
+    assert payload["mhr"] == 193
+
+
+def test_sync_zones_json_sync_error(tmp_path: Path, monkeypatch, capsys):
+    env_file = tmp_path / ".env"
+    _write_env(env_file)
+
+    def fake_sync(config, progress=None):
+        raise core.SyncError("profile update failed")
+
+    monkeypatch.setattr(cli, "sync_profile_zones", fake_sync)
+
+    args = cli._build_parser().parse_args(
+        ["sync-zones", "--env-file", str(env_file), "--json"]
+    )
+    assert cli.cmd_sync_zones(args) == cli.EXIT_SYNC_ERROR
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"] == "profile update failed"

--- a/tests/test_intervals_icu.py
+++ b/tests/test_intervals_icu.py
@@ -63,3 +63,25 @@ def test_fetch_sport_settings_max_hr(monkeypatch):
     assert intervals_icu.fetch_sport_settings_max_hr("api-key", "Ride") == 193.0
     assert captured["url"].endswith("/sport-settings/Ride")
     assert captured["auth"] == ("API_KEY", "api-key")
+
+
+def test_fetch_sport_settings(monkeypatch):
+    monkeypatch.setattr(
+        intervals_icu.requests.Session,
+        "get",
+        lambda self, *a, **k: FakeResponse(
+            json_data={
+                "ftp": 242,
+                "lthr": 176,
+                "max_hr": 193,
+                "power_zones": [55, 75, 90, 105, 120, 999],
+                "hr_zones": [120, 146, 166, 185, 193],
+            }
+        ),
+    )
+    settings = intervals_icu.fetch_sport_settings("api-key", "Ride")
+    assert settings.ftp == 242.0
+    assert settings.lthr == 176.0
+    assert settings.max_hr == 193.0
+    assert settings.power_zones == [55.0, 75.0, 90.0, 105.0, 120.0, 999.0]
+    assert settings.hr_zones == [120.0, 146.0, 166.0, 185.0, 193.0]

--- a/tests/test_profile_sync.py
+++ b/tests/test_profile_sync.py
@@ -1,0 +1,95 @@
+"""Tests for intervals.icu → iGPSPORT profile sync orchestration."""
+
+from __future__ import annotations
+
+from intervalssync.igpsport.profile_sync import (
+    ProfileSyncConfig,
+    apply_intervals_settings,
+)
+from intervalssync.intervals_icu import SportSettings
+
+
+def _igpsport_payload(*, power_count: int = 7, hr_count: int = 5) -> dict:
+    return {
+        "member": {
+            "ftp": 240,
+            "mhr": 190,
+            "lthr": 150,
+            "heartRateComputeMode": 2,
+            "quietHeartRate": 60,
+        },
+        "power": [{"id": index, "start": 0, "end": 100 + index} for index in range(power_count)],
+        "heartRate": [{"id": index, "start": 0, "end": 100 + index} for index in range(hr_count)],
+    }
+
+
+def test_apply_intervals_settings_updates_thresholds_and_zones():
+    settings = SportSettings(
+        ftp=242,
+        lthr=176,
+        max_hr=193,
+        power_zones=[55, 75, 90, 105, 120, 999],
+        hr_zones=[120, 146, 166, 185, 193],
+    )
+    updated = apply_intervals_settings(_igpsport_payload(), settings)
+
+    assert updated["member"]["ftp"] == 242
+    assert updated["member"]["lthr"] == 176
+    assert updated["member"]["mhr"] == 193
+    assert updated["member"]["heartRateComputeMode"] == 0
+    assert len(updated["power"]) == 7
+    assert updated["power"][0]["end"] == 133
+    assert updated["power"][-1]["end"] == 1999
+    assert [zone["end"] for zone in updated["heartRate"]] == [120, 146, 166, 185, 193]
+
+
+def test_apply_intervals_settings_keeps_other_member_fields():
+    body = _igpsport_payload()
+    settings = SportSettings(242, 176, 193, [55, 75, 90, 105, 120, 999], [120, 146, 166, 185, 193])
+    updated = apply_intervals_settings(body, settings)
+    assert updated["member"]["quietHeartRate"] == 60
+
+
+def test_sync_profile_zones_end_to_end(monkeypatch):
+    from intervalssync.igpsport import profile_sync
+
+    posted: dict = {}
+
+    settings = SportSettings(
+        ftp=242,
+        lthr=176,
+        max_hr=193,
+        power_zones=[55, 75, 90, 105, 120, 999],
+        hr_zones=[120, 146, 166, 185, 193],
+    )
+    current = _igpsport_payload()
+
+    monkeypatch.setattr(profile_sync, "login", lambda *a, **k: {"Authorization": "Bearer x"})
+    monkeypatch.setattr(profile_sync, "member_id_from_token", lambda *a, **k: 1171353)
+    monkeypatch.setattr(
+        profile_sync.intervals_icu,
+        "fetch_sport_settings",
+        lambda *a, **k: settings,
+    )
+
+    calls = {"get": 0}
+
+    def fake_fetch(session, headers):
+        calls["get"] += 1
+        return current if calls["get"] == 1 else apply_intervals_settings(current, settings)
+
+    def fake_update(session, headers, body):
+        posted["body"] = body
+        return {"code": 0}
+
+    monkeypatch.setattr(profile_sync, "fetch_personal_interval_info", fake_fetch)
+    monkeypatch.setattr(profile_sync, "update_personal_interval_info", fake_update)
+
+    result = profile_sync.sync_profile_zones(
+        ProfileSyncConfig("user", "pass", "api-key"),
+        progress=lambda _message: None,
+    )
+
+    assert posted["body"]["member"]["ftp"] == 242
+    assert result.after is not None
+    assert result.after["member"]["mhr"] == 193

--- a/tests/test_profile_sync.py
+++ b/tests/test_profile_sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from intervalssync.igpsport.profile_sync import (
     ProfileSyncConfig,
     apply_intervals_settings,
+    compare_profile_thresholds,
 )
 from intervalssync.intervals_icu import SportSettings
 
@@ -49,6 +50,87 @@ def test_apply_intervals_settings_keeps_other_member_fields():
     settings = SportSettings(242, 176, 193, [55, 75, 90, 105, 120, 999], [120, 146, 166, 185, 193])
     updated = apply_intervals_settings(body, settings)
     assert updated["member"]["quietHeartRate"] == 60
+
+
+def _ride_settings(**overrides: object) -> SportSettings:
+    defaults = {
+        "ftp": 242,
+        "lthr": 176,
+        "max_hr": 193,
+        "power_zones": [55, 75, 90, 105, 120, 999],
+        "hr_zones": [120, 146, 166, 185, 193],
+    }
+    defaults.update(overrides)
+    return SportSettings(**defaults)
+
+
+def test_compare_profile_thresholds_in_sync():
+    body = apply_intervals_settings(_igpsport_payload(), _ride_settings())
+    status = compare_profile_thresholds(body, _ride_settings())
+    assert status.needs_sync is False
+    assert status.differences == []
+    assert status.intervals_fingerprint == "242|176|193"
+
+
+def test_compare_profile_thresholds_ftp_mismatch():
+    status = compare_profile_thresholds(_igpsport_payload(), _ride_settings())
+    assert status.needs_sync is True
+    assert len(status.differences) == 3
+    assert status.differences[0].startswith("FTP:")
+
+
+def test_compare_profile_thresholds_lthr_mismatch_only():
+    body = _igpsport_payload()
+    body["member"]["ftp"] = 242
+    body["member"]["mhr"] = 193
+    status = compare_profile_thresholds(body, _ride_settings())
+    assert status.needs_sync is True
+    assert status.differences == ["LTHR: iGPSPORT 150 → intervals.icu 176"]
+
+
+def test_compare_profile_thresholds_mhr_mismatch_only():
+    body = _igpsport_payload()
+    body["member"]["ftp"] = 242
+    body["member"]["lthr"] = 176
+    status = compare_profile_thresholds(body, _ride_settings())
+    assert status.needs_sync is True
+    assert status.differences == ["max HR: iGPSPORT 190 → intervals.icu 193"]
+
+
+def test_compare_profile_thresholds_skips_lthr_when_intervals_missing():
+    body = _igpsport_payload()
+    body["member"]["ftp"] = 242
+    body["member"]["mhr"] = 193
+    settings = _ride_settings(lthr=None)
+    status = compare_profile_thresholds(body, settings)
+    assert status.needs_sync is False
+    assert status.intervals_fingerprint == "242||193"
+
+
+def test_fetch_profile_threshold_status(monkeypatch):
+    from intervalssync.igpsport import profile_sync
+
+    settings = _ride_settings()
+    current = _igpsport_payload()
+
+    monkeypatch.setattr(profile_sync, "login", lambda *a, **k: {"Authorization": "Bearer x"})
+    monkeypatch.setattr(profile_sync, "member_id_from_token", lambda *a, **k: 1171353)
+    monkeypatch.setattr(
+        profile_sync.intervals_icu,
+        "fetch_sport_settings",
+        lambda *a, **k: settings,
+    )
+    monkeypatch.setattr(
+        profile_sync,
+        "fetch_personal_interval_info",
+        lambda *a, **k: current,
+    )
+
+    status = profile_sync.fetch_profile_threshold_status(
+        ProfileSyncConfig("user", "pass", "api-key"),
+    )
+    assert status.needs_sync is True
+    assert any(diff.startswith("FTP:") for diff in status.differences)
 
 
 def test_sync_profile_zones_end_to_end(monkeypatch):

--- a/tests/test_profile_sync.py
+++ b/tests/test_profile_sync.py
@@ -39,7 +39,8 @@ def test_apply_intervals_settings_updates_thresholds_and_zones():
     assert updated["member"]["heartRateComputeMode"] == 0
     assert len(updated["power"]) == 7
     assert updated["power"][0]["end"] == 133
-    assert updated["power"][-1]["end"] == 1999
+    assert updated["power"][-1]["end"] == 2500
+    assert updated["power"][-2]["end"] <= 1999
     assert [zone["end"] for zone in updated["heartRate"]] == [120, 146, 166, 185, 193]
 
 

--- a/tests/test_zone_map.py
+++ b/tests/test_zone_map.py
@@ -1,0 +1,87 @@
+"""Tests for intervals.icu → iGPSPORT zone mapping."""
+
+from __future__ import annotations
+
+from intervalssync.igpsport.zone_map import (
+    POWER_ZONE_CAP,
+    hr_upper_bounds_bpm,
+    map_hr_zones,
+    map_power_zones,
+    power_upper_bounds_watts,
+)
+
+
+def _template_zones(count: int) -> list[dict]:
+    return [{"id": index, "start": 0, "end": 0} for index in range(count)]
+
+
+# settings-ride.json reference values
+FTP = 242
+POWER_PCT = [55, 75, 90, 105, 120, 999]
+HR_BPM = [120, 146, 166, 185, 193]
+MAX_HR = 193
+
+
+def test_power_upper_bounds_from_settings_ride():
+    assert power_upper_bounds_watts(POWER_PCT, FTP) == [133, 182, 218, 254, 290, 1999]
+
+
+def test_hr_upper_bounds_from_settings_ride():
+    assert hr_upper_bounds_bpm(HR_BPM, MAX_HR) == [120, 146, 166, 185, 193]
+
+
+def test_map_power_same_count_seven_slots():
+    zones = map_power_zones(POWER_PCT, FTP, _template_zones(6))
+    assert len(zones) == 6
+    assert zones[0]["start"] == 0 and zones[0]["end"] == 133
+    assert zones[-1]["end"] == 1999
+
+
+def test_map_power_fewer_intervals_than_igpsport():
+    zones = map_power_zones(POWER_PCT, FTP, _template_zones(7))
+    assert len(zones) == 7
+    assert zones[4]["end"] == 290
+    assert zones[-1]["end"] == POWER_ZONE_CAP
+    assert zones[-1]["start"] == zones[-2]["end"]
+
+
+def test_map_power_more_intervals_than_igpsport():
+    intervals_pct = [55, 65, 75, 85, 90, 105, 120]
+    zones = map_power_zones(intervals_pct, FTP, _template_zones(5))
+    assert len(zones) == 5
+    assert zones[3]["end"] == int(round(FTP * 0.85))
+    assert zones[4]["start"] == zones[3]["end"]
+    assert zones[4]["end"] == int(round(FTP * 1.20))
+
+
+def test_map_hr_same_count():
+    zones = map_hr_zones(HR_BPM, MAX_HR, _template_zones(5))
+    assert [zone["end"] for zone in zones] == [120, 146, 166, 185, 193]
+
+
+def test_map_hr_fewer_intervals_than_igpsport():
+    zones = map_hr_zones(HR_BPM[:3], MAX_HR, _template_zones(5))
+    assert zones[2]["end"] == 166
+    assert zones[-1]["end"] == MAX_HR
+    assert zones[-2]["end"] == MAX_HR - 1
+
+
+def test_map_hr_more_intervals_than_igpsport():
+    intervals = [110, 130, 150, 165, 175, 185, MAX_HR]
+    zones = map_hr_zones(intervals, MAX_HR, _template_zones(5))
+    assert zones[3]["end"] == 165
+    assert zones[4]["start"] == 165
+    assert zones[4]["end"] == MAX_HR
+
+
+def test_map_power_dedupes_equal_boundaries():
+    zones = map_power_zones([55, 55, 75, 90, 105, 120], FTP, _template_zones(6))
+    assert zones[0]["end"] == 133
+    assert zones[1]["end"] > zones[0]["end"]
+
+
+def test_map_power_preserves_zone_metadata():
+    template = [{"id": "zone-a", "color": "#fff", "start": 99, "end": 999}]
+    zones = map_power_zones([55], FTP, template)
+    assert zones[0]["id"] == "zone-a"
+    assert zones[0]["color"] == "#fff"

--- a/tests/test_zone_map.py
+++ b/tests/test_zone_map.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from intervalssync.igpsport.zone_map import (
-    POWER_ZONE_CAP,
+    POWER_INTERIOR_CAP,
+    POWER_LAST_ZONE_END,
     hr_upper_bounds_bpm,
     map_hr_zones,
     map_power_zones,
@@ -23,7 +24,7 @@ MAX_HR = 193
 
 
 def test_power_upper_bounds_from_settings_ride():
-    assert power_upper_bounds_watts(POWER_PCT, FTP) == [133, 182, 218, 254, 290, 1999]
+    assert power_upper_bounds_watts(POWER_PCT, FTP) == [133, 182, 218, 254, 290, 2418]
 
 
 def test_hr_upper_bounds_from_settings_ride():
@@ -34,14 +35,16 @@ def test_map_power_same_count_seven_slots():
     zones = map_power_zones(POWER_PCT, FTP, _template_zones(6))
     assert len(zones) == 6
     assert zones[0]["start"] == 0 and zones[0]["end"] == 133
-    assert zones[-1]["end"] == 1999
+    assert zones[-1]["end"] == POWER_LAST_ZONE_END
+    assert zones[-2]["end"] <= POWER_INTERIOR_CAP
 
 
 def test_map_power_fewer_intervals_than_igpsport():
     zones = map_power_zones(POWER_PCT, FTP, _template_zones(7))
     assert len(zones) == 7
     assert zones[4]["end"] == 290
-    assert zones[-1]["end"] == POWER_ZONE_CAP
+    assert zones[-1]["end"] == POWER_LAST_ZONE_END
+    assert zones[-2]["end"] <= POWER_INTERIOR_CAP
     assert zones[-1]["start"] == zones[-2]["end"]
 
 
@@ -49,9 +52,10 @@ def test_map_power_more_intervals_than_igpsport():
     intervals_pct = [55, 65, 75, 85, 90, 105, 120]
     zones = map_power_zones(intervals_pct, FTP, _template_zones(5))
     assert len(zones) == 5
-    assert zones[3]["end"] == int(round(FTP * 0.85))
+    assert zones[3]["end"] == int(round(FTP * 1.20))
+    assert zones[3]["end"] <= POWER_INTERIOR_CAP
     assert zones[4]["start"] == zones[3]["end"]
-    assert zones[4]["end"] == int(round(FTP * 1.20))
+    assert zones[4]["end"] == POWER_LAST_ZONE_END
 
 
 def test_map_hr_same_count():


### PR DESCRIPTION
## Summary
- Add `intervalssync sync-zones` CLI to push FTP, LTHR, max HR, and power/HR zones from intervals.icu sport settings into the iGPSPORT profile
- Expose the same flow in the GUI under Settings → iGPSPORT profile, with a manual sync button and an optional launch-time prompt when thresholds differ
- Map intervals.icu zone boundaries onto existing iGPSPORT zone slots (pad/truncate), capping interior power zones at 1999 W and the last zone at 2500 W

## Test plan
- [ ] `uv run pytest`
- [ ] `uv run intervalssync sync-zones --env-file .env` updates FTP/LTHR/max HR and zones on iGPSPORT
- [ ] GUI: Settings → iGPSPORT profile → Sync profile now succeeds with valid credentials
- [ ] GUI: launch prompt appears when FTP/LTHR/max HR differ; Not now suppresses until intervals.icu thresholds change
- [ ] GUI: disabling Check on app launch skips the startup prompt