### PR TITLE
fix(ci): restore root main.py for Flet build entry point

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           python -c "from pathlib import Path; import os; Path('src/intervalssync/_dropbox_app_key.py').write_text('DROPBOX_APP_KEY = ' + repr(os.getenv('IGPSYNC_DROPBOX_APP_KEY', '')) + '\n', encoding='utf-8')"
 
       - name: Build Windows app
-        run: uv run flet build windows --yes --verbose --module-name intervalssync.gui.app --build-version "${{ env.APP_VERSION }}"
+        run: uv run flet build windows --yes --verbose --build-version "${{ env.APP_VERSION }}"
 
       # Name the zip after the tag, e.g. intervalssync-v0.2.0-windows.zip
       - name: Package into a versioned zip
@@ -102,7 +102,7 @@ jobs:
       # flet build apk auto-installs the Flutter/Android SDK + JDK on first run.
       # It picks up the FLET_ANDROID_SIGNING_* env vars set above when present.
       - name: Build Android APK
-        run: uv run flet build apk --yes --verbose --module-name intervalssync.gui.app --build-version "${{ env.APP_VERSION }}"
+        run: uv run flet build apk --yes --verbose --build-version "${{ env.APP_VERSION }}"
 
       - name: Rename APK with the version
         run: mv build/apk/*.apk "intervalssync-${{ github.ref_name }}-android.apk"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ uv run --env-file .env intervalssync-gui
 ## Build the Windows executable
 
 ```bash
-uv run flet build windows --module-name intervalssync.gui.app
+uv run flet build windows
 ```
 
 The distributable lands in `build/windows/`. (Flet downloads the Flutter

--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+"""Entry point — launches the GUI.
+
+    uv run main.py
+"""
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    src = Path(__file__).resolve().parent / "src"
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    from intervalssync.gui.app import main as gui_main
+
+    gui_main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Restore root `main.py` launcher removed in #35
- Revert incorrect `--module-name intervalssync.gui.app` from #39

Flet expects a filename stem (`main.py`), not a Python import path. CI error: `intervalssync.gui.py not found in the root of Flet app directory`.

## Test plan
- [ ] Re-tag `v0.7.0-rc1` and confirm Release workflow completes

Made with [Cursor](https://cursor.com)