### PR TITLE
fix(gui): restore macos settings flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,3 @@ bundle_id = "io.github.jorgehuxley.intervalssync"
 "android.permission.MANAGE_EXTERNAL_STORAGE" = true
 "android.permission.READ_EXTERNAL_STORAGE" = true
 "android.permission.WRITE_EXTERNAL_STORAGE" = true
-
-# macOS secure storage needs the login keychain path for unsigned/non-App-Store
-# builds. This Flutter plugin version honors `usesDataProtectionKeychain=false`.
-[tool.flet.flutter.pubspec.dependency_overrides]
-flutter_secure_storage = "10.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,8 @@ bundle_id = "io.github.jorgehuxley.intervalssync"
 "android.permission.MANAGE_EXTERNAL_STORAGE" = true
 "android.permission.READ_EXTERNAL_STORAGE" = true
 "android.permission.WRITE_EXTERNAL_STORAGE" = true
+
+# macOS secure storage needs the login keychain path for unsigned/non-App-Store
+# builds. This Flutter plugin version honors `usesDataProtectionKeychain=false`.
+[tool.flet.flutter.pubspec.dependency_overrides]
+flutter_secure_storage = "10.3.1"

--- a/src/intervalssync/gui/app.py
+++ b/src/intervalssync/gui/app.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import flet as ft
 from flet_permission_handler import Permission, PermissionHandler, PermissionStatus
-from flet_secure_storage import MacOsOptions, SecureStorage
+from flet_secure_storage import SecureStorage
 
 from .. import __version__
 from . import config as config_module
@@ -63,12 +63,14 @@ def _supports_permission_handler(platform: ft.PagePlatform) -> bool:
     return platform in _PERMISSION_HANDLER_PLATFORMS
 
 
-def _secure_storage_for_platform(platform: ft.PagePlatform) -> SecureStorage:
+def _secret_store_for_platform(
+    platform: ft.PagePlatform,
+) -> tuple[secrets_module.SecretStore, SecureStorage | None]:
     if platform == ft.PagePlatform.MACOS:
-        return SecureStorage(
-            macos_options=MacOsOptions(uses_data_protection_keychain=False)
-        )
-    return SecureStorage()
+        return secrets_module.MacOSKeychainStore(), None
+
+    storage = SecureStorage()
+    return secrets_module.FletSecureStorage(storage), storage
 
 
 async def _app(page: ft.Page) -> None:
@@ -86,12 +88,12 @@ async def _app(page: ft.Page) -> None:
 
     config = config_module.load()
 
-    storage = _secure_storage_for_platform(page.platform)
+    store, storage = _secret_store_for_platform(page.platform)
     perms = PermissionHandler() if _supports_permission_handler(page.platform) else None
-    page.services.append(storage)
+    if storage is not None:
+        page.services.append(storage)
     if perms is not None:
         page.services.append(perms)
-    store = secrets_module.FletSecureStorage(storage)
 
     def _private_download_dir() -> str:
         base = os.getenv("FLET_APP_STORAGE_DATA") or tempfile.gettempdir()

--- a/src/intervalssync/gui/app.py
+++ b/src/intervalssync/gui/app.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import flet as ft
 from flet_permission_handler import Permission, PermissionHandler, PermissionStatus
-from flet_secure_storage import SecureStorage
+from flet_secure_storage import MacOsOptions, SecureStorage
 
 from .. import __version__
 from . import config as config_module
@@ -63,6 +63,14 @@ def _supports_permission_handler(platform: ft.PagePlatform) -> bool:
     return platform in _PERMISSION_HANDLER_PLATFORMS
 
 
+def _secure_storage_for_platform(platform: ft.PagePlatform) -> SecureStorage:
+    if platform == ft.PagePlatform.MACOS:
+        return SecureStorage(
+            macos_options=MacOsOptions(uses_data_protection_keychain=False)
+        )
+    return SecureStorage()
+
+
 async def _app(page: ft.Page) -> None:
     page.title = APP_TITLE
     page.theme_mode = ft.ThemeMode.SYSTEM
@@ -78,7 +86,7 @@ async def _app(page: ft.Page) -> None:
 
     config = config_module.load()
 
-    storage = SecureStorage()
+    storage = _secure_storage_for_platform(page.platform)
     perms = PermissionHandler() if _supports_permission_handler(page.platform) else None
     page.services.append(storage)
     if perms is not None:

--- a/src/intervalssync/gui/app.py
+++ b/src/intervalssync/gui/app.py
@@ -23,6 +23,13 @@ from . import theme
 
 _DESKTOP = {ft.PagePlatform.WINDOWS, ft.PagePlatform.MACOS, ft.PagePlatform.LINUX}
 _MOBILE = {ft.PagePlatform.ANDROID, ft.PagePlatform.ANDROID_TV, ft.PagePlatform.IOS}
+_PERMISSION_HANDLER_PLATFORMS = {
+    ft.PagePlatform.ANDROID,
+    ft.PagePlatform.ANDROID_TV,
+    ft.PagePlatform.IOS,
+    ft.PagePlatform.WINDOWS,
+    *([ft.PagePlatform.WEB] if hasattr(ft.PagePlatform, "WEB") else []),
+}
 # Standard public Downloads directory on Android (the filesystem name is the
 # singular "Download"). Used when the user opts in and grants storage access.
 ANDROID_DOWNLOADS = "/storage/emulated/0/Download/intervalssync-fit"
@@ -52,6 +59,10 @@ async def _has_credentials(
     return False
 
 
+def _supports_permission_handler(platform: ft.PagePlatform) -> bool:
+    return platform in _PERMISSION_HANDLER_PLATFORMS
+
+
 async def _app(page: ft.Page) -> None:
     page.title = APP_TITLE
     page.theme_mode = ft.ThemeMode.SYSTEM
@@ -68,8 +79,10 @@ async def _app(page: ft.Page) -> None:
     config = config_module.load()
 
     storage = SecureStorage()
-    perms = PermissionHandler()
-    page.services.extend([storage, perms])
+    perms = PermissionHandler() if _supports_permission_handler(page.platform) else None
+    page.services.append(storage)
+    if perms is not None:
+        page.services.append(perms)
     store = secrets_module.FletSecureStorage(storage)
 
     def _private_download_dir() -> str:

--- a/src/intervalssync/gui/secrets.py
+++ b/src/intervalssync/gui/secrets.py
@@ -1,16 +1,18 @@
 """Secure secret storage.
 
 Secrets are kept in the operating system's native vault (Windows Credential
-Manager, macOS/iOS Keychain, Android Keystore, Linux libsecret) via
-`flet-secure-storage` — never in a plaintext file. Platform-specific options
-are handled at app startup before this wrapper is created.
+Manager, macOS Keychain, Android Keystore, Linux libsecret) — never in a
+plaintext file.
 
-`SecretStore` is the async seam between the GUI and storage. It's async because
-`flet-secure-storage` talks to the Flutter side asynchronously.
+`SecretStore` is the async seam between the GUI and storage. Most platforms use
+`flet-secure-storage`, while macOS uses the native `security` CLI to avoid
+Flet's prebuilt desktop runner hitting Keychain entitlement errors.
 """
 
 from __future__ import annotations
 
+import asyncio
+import subprocess
 from abc import ABC, abstractmethod
 
 from flet_secure_storage import SecureStorage
@@ -20,6 +22,7 @@ IGP_PASSWORD = "igp_password"
 BRYTON_PASSWORD = "bryton_password"
 INTERVALS_API_KEY = "intervals_api_key"
 DROPBOX_REFRESH_TOKEN = "dropbox_refresh_token"
+MACOS_KEYCHAIN_SERVICE = "io.github.jorgehuxley.intervalssync"
 
 
 class SecretStore(ABC):
@@ -51,3 +54,82 @@ class FletSecureStorage(SecretStore):
 
     async def delete(self, key: str) -> None:
         await self._storage.remove(key)
+
+
+class MacOSKeychainStore(SecretStore):
+    """Stores secrets in the user's macOS login Keychain."""
+
+    def __init__(self, service: str = MACOS_KEYCHAIN_SERVICE) -> None:
+        self._service = service
+
+    async def get(self, key: str) -> str | None:
+        return await asyncio.to_thread(self._get_sync, key)
+
+    async def set(self, key: str, value: str) -> None:
+        await asyncio.to_thread(self._set_sync, key, value)
+
+    async def delete(self, key: str) -> None:
+        await asyncio.to_thread(self._delete_sync, key)
+
+    def _get_sync(self, key: str) -> str | None:
+        result = self._run_security(
+            "find-generic-password",
+            "-s",
+            self._service,
+            "-a",
+            key,
+            "-w",
+        )
+        if result.returncode == 0:
+            return result.stdout.removesuffix("\n")
+        if _is_missing_keychain_item(result):
+            return None
+        raise _keychain_error("read", key, result)
+
+    def _set_sync(self, key: str, value: str) -> None:
+        result = self._run_security(
+            "add-generic-password",
+            "-U",
+            "-s",
+            self._service,
+            "-a",
+            key,
+            "-w",
+            value,
+        )
+        if result.returncode != 0:
+            raise _keychain_error("save", key, result)
+
+    def _delete_sync(self, key: str) -> None:
+        result = self._run_security(
+            "delete-generic-password",
+            "-s",
+            self._service,
+            "-a",
+            key,
+        )
+        if result.returncode == 0 or _is_missing_keychain_item(result):
+            return
+        raise _keychain_error("delete", key, result)
+
+    def _run_security(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["security", *args],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+
+def _is_missing_keychain_item(result: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    return result.returncode == 44 or "could not be found" in output
+
+
+def _keychain_error(
+    action: str,
+    key: str,
+    result: subprocess.CompletedProcess[str],
+) -> RuntimeError:
+    detail = (result.stderr or result.stdout or f"exit code {result.returncode}").strip()
+    return RuntimeError(f"Could not {action} Keychain item {key!r}: {detail}")

--- a/src/intervalssync/gui/secrets.py
+++ b/src/intervalssync/gui/secrets.py
@@ -2,8 +2,8 @@
 
 Secrets are kept in the operating system's native vault (Windows Credential
 Manager, macOS/iOS Keychain, Android Keystore, Linux libsecret) via
-`flet-secure-storage` — never in a plaintext file. The same backend works on
-every platform Flet targets, so there is no per-OS branching.
+`flet-secure-storage` — never in a plaintext file. Platform-specific options
+are handled at app startup before this wrapper is created.
 
 `SecretStore` is the async seam between the GUI and storage. It's async because
 `flet-secure-storage` talks to the Flutter side asynchronously.

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import flet as ft
 
 from intervalssync.gui import app
+from intervalssync.gui import secrets as secrets_module
 
 
 def test_permission_handler_skips_unsupported_desktop_platforms():
@@ -20,13 +21,15 @@ def test_permission_handler_allows_supported_platforms():
         assert app._supports_permission_handler(web)
 
 
-def test_secure_storage_uses_login_keychain_on_macos():
-    storage = app._secure_storage_for_platform(ft.PagePlatform.MACOS)
+def test_secret_store_uses_native_keychain_on_macos():
+    store, storage = app._secret_store_for_platform(ft.PagePlatform.MACOS)
 
-    assert storage.macos_options.uses_data_protection_keychain is False
+    assert isinstance(store, secrets_module.MacOSKeychainStore)
+    assert storage is None
 
 
-def test_secure_storage_keeps_default_keychain_options_elsewhere():
-    storage = app._secure_storage_for_platform(ft.PagePlatform.WINDOWS)
+def test_secret_store_uses_flet_secure_storage_elsewhere():
+    store, storage = app._secret_store_for_platform(ft.PagePlatform.WINDOWS)
 
-    assert storage.macos_options.uses_data_protection_keychain is True
+    assert isinstance(store, secrets_module.FletSecureStorage)
+    assert storage is not None

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import flet as ft
+
+from intervalssync.gui import app
+
+
+def test_permission_handler_skips_unsupported_desktop_platforms():
+    assert not app._supports_permission_handler(ft.PagePlatform.MACOS)
+    assert not app._supports_permission_handler(ft.PagePlatform.LINUX)
+
+
+def test_permission_handler_allows_supported_platforms():
+    assert app._supports_permission_handler(ft.PagePlatform.ANDROID)
+    assert app._supports_permission_handler(ft.PagePlatform.IOS)
+    assert app._supports_permission_handler(ft.PagePlatform.WINDOWS)
+
+    web = getattr(ft.PagePlatform, "WEB", None)
+    if web is not None:
+        assert app._supports_permission_handler(web)

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -18,3 +18,15 @@ def test_permission_handler_allows_supported_platforms():
     web = getattr(ft.PagePlatform, "WEB", None)
     if web is not None:
         assert app._supports_permission_handler(web)
+
+
+def test_secure_storage_uses_login_keychain_on_macos():
+    storage = app._secure_storage_for_platform(ft.PagePlatform.MACOS)
+
+    assert storage.macos_options.uses_data_protection_keychain is False
+
+
+def test_secure_storage_keeps_default_keychain_options_elsewhere():
+    storage = app._secure_storage_for_platform(ft.PagePlatform.WINDOWS)
+
+    assert storage.macos_options.uses_data_protection_keychain is True

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -8,6 +8,7 @@ round-trip is verified by running the app, not in unit tests.
 from __future__ import annotations
 
 import asyncio
+import subprocess
 
 from intervalssync.gui import secrets as secrets_module
 
@@ -28,6 +29,26 @@ class FakeSecureStorage:
         self.data.pop(key, None)
 
 
+class FakeMacOSKeychainStore(secrets_module.MacOSKeychainStore):
+    def __init__(self, results):
+        super().__init__(service="test.service")
+        self.results = list(results)
+        self.calls: list[tuple[str, ...]] = []
+
+    def _run_security(self, *args):
+        self.calls.append(args)
+        return self.results.pop(0)
+
+
+def security_result(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["security"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
 def test_fletsecurestorage_delegates():
     store = secrets_module.FletSecureStorage(FakeSecureStorage())
 
@@ -37,6 +58,87 @@ def test_fletsecurestorage_delegates():
         assert await store.get("k") == "secret"
         await store.delete("k")
         assert await store.get("k") is None
+
+    asyncio.run(scenario())
+
+
+def test_macos_keychain_store_uses_security_cli():
+    store = FakeMacOSKeychainStore(
+        [
+            security_result(stdout="secret\n"),
+            security_result(),
+            security_result(),
+        ]
+    )
+
+    async def scenario():
+        assert await store.get("k") == "secret"
+        await store.set("k", "new-secret")
+        await store.delete("k")
+
+    asyncio.run(scenario())
+
+    assert store.calls == [
+        (
+            "find-generic-password",
+            "-s",
+            "test.service",
+            "-a",
+            "k",
+            "-w",
+        ),
+        (
+            "add-generic-password",
+            "-U",
+            "-s",
+            "test.service",
+            "-a",
+            "k",
+            "-w",
+            "new-secret",
+        ),
+        (
+            "delete-generic-password",
+            "-s",
+            "test.service",
+            "-a",
+            "k",
+        ),
+    ]
+
+
+def test_macos_keychain_store_returns_none_for_missing_secret():
+    store = FakeMacOSKeychainStore(
+        [security_result(returncode=44, stderr="The specified item could not be found.")]
+    )
+
+    async def scenario():
+        assert await store.get("missing") is None
+
+    asyncio.run(scenario())
+
+
+def test_macos_keychain_store_ignores_delete_for_missing_secret():
+    store = FakeMacOSKeychainStore(
+        [security_result(returncode=44, stderr="The specified item could not be found.")]
+    )
+
+    async def scenario():
+        await store.delete("missing")
+
+    asyncio.run(scenario())
+
+
+def test_macos_keychain_store_raises_other_errors():
+    store = FakeMacOSKeychainStore([security_result(returncode=1, stderr="boom")])
+
+    async def scenario():
+        try:
+            await store.set("k", "secret")
+        except RuntimeError as exc:
+            assert "Could not save Keychain item 'k': boom" == str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix the macOS GUI failures reported during startup and settings save. The app no longer registers Flet's unsupported permission handler service on macOS/Linux, and `uv run intervalssync-gui` now saves credentials through the native macOS Keychain CLI instead of Flet's prebuilt secure-storage plugin, avoiding the `-34018` missing-entitlement error.

## Changes

- Gate `PermissionHandler` creation/registration by Flet platform.
- Keep macOS and Linux desktops out of the permission handler path.
- Add a `MacOSKeychainStore` that uses the native `security` command for macOS secrets.
- Wire macOS GUI startup to use the native Keychain store and skip Flet `SecureStorage` registration.
- Keep Flet secure storage for non-macOS platforms.
- Add regression tests for permission support, app secret-store selection, and macOS Keychain command behavior.

## Verification

- [x] Tests pass (`uv run pytest`)
- Focused regression check: `uv run pytest tests/test_gui_app.py tests/test_secrets.py`

## Notes / follow-ups

- This directly targets the `uv run intervalssync-gui` path, where Flet's prebuilt desktop runtime can still contain the upstream secure-storage plugin issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06450993-31d0-43ef-b7fd-4a10e7ea23a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06450993-31d0-43ef-b7fd-4a10e7ea23a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

