### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+See `CLAUDE.md` for architecture, `README.md` for an overview, `CONTRIBUTING.md`
+for contributor setup, and `docs/AGENT.md` for the headless CLI. The commands
+below live in those files; this section only adds non-obvious cloud caveats.
+
+## Cursor Cloud specific instructions
+
+This is a Python 3.13 project managed by [uv](https://docs.astral.sh/uv/).
+Dependencies are refreshed automatically by the startup update script (`uv sync`).
+`uv` is installed at `~/.local/bin` and put on `PATH` via `~/.bashrc`.
+
+### Services
+
+- **Tests** (offline, no network): `uv run pytest`. Standard command; see `CLAUDE.md`.
+- **CLI** (`intervalssync`): headless. `uv run intervalssync check` validates
+  credentials with no network. Full commands in `docs/AGENT.md`. Exit codes:
+  `0` ok, `1` sync error, `2` missing credentials.
+- **GUI** (`intervalssync-gui`): a Flet app. See below — it needs a special
+  run mode on Linux.
+
+### Running the GUI on Linux (non-obvious)
+
+The GUI targets Windows/Android as a native Flet desktop app. On this Linux VM
+the native desktop client does **not** work: `flet-secure-storage` /
+`flet-permission-handler` raise `FletUnsupportedPlatformException`
+("only supported on Android, iOS, Windows, and Web platforms"), and the desktop
+Flutter client also needs GL/GTK system libraries.
+
+Run it as a **web app** instead (Web is a supported platform, so the vault +
+permission services load). No system graphics libraries are needed in web mode:
+
+```bash
+FLET_FORCE_WEB_SERVER=true FLET_SERVER_PORT=8550 FLET_SERVER_IP=0.0.0.0 uv run intervalssync-gui
+```
+
+Then open `http://localhost:8550/`. The first web launch auto-installs the
+`flet-web` extra (fastapi/uvicorn/etc.) into the venv, so allow a few seconds.
+In web mode the OS secure vault is emulated in the browser, which is fine for
+development and testing.
+
+### Notes
+
+- No linter/formatter is configured; CI (`.github/workflows/test.yml`) only runs
+  `uv run pytest`.
+- Credentials for the CLI come from a `.env` file (see `.env.example` /
+  `docs/AGENT.md`); pass it with `--env-file PATH` on the `intervalssync`
+  subcommand (not as a `uv run` flag). Never commit real secrets.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cursor Cloud agents and documents non-obvious run caveats. No application code changed — only adds `AGENTS.md`.

The environment is a Python 3.13 project managed by `uv`. Verified end-to-end:

- Dependencies install via `uv sync` (Python 3.13.14).
- Test suite passes: `uv run pytest` → 162 passed.
- CLI works: `uv run intervalssync check --env-file ...` returns correct JSON + exit codes.
- GUI runs as a Flet **web app** (the native Linux desktop client is unsupported by `flet-permission-handler`/`flet-secure-storage`). Confirmed a hello-world flow: entered demo credentials in Settings, saved to the secure store, and navigated to the Sync screen.

## AGENTS.md

Adds a `## Cursor Cloud specific instructions` section covering:

- Running the GUI on Linux via `FLET_FORCE_WEB_SERVER=true FLET_SERVER_PORT=8550 uv run intervalssync-gui`.
- No linter configured (CI only runs `pytest`).
- CLI credential handling via `--env-file`.

## Walkthrough

[intervals_sync_gui_demo.mp4](https://cursor.com/agents/bc-a0f52080-bf07-4948-8dde-0ff1db4c9f71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintervals_sync_gui_demo.mp4)

GUI loaded in a browser, demo credentials saved to the secure store, and the app navigated to the Sync screen.

[Settings screen](https://cursor.com/agents/bc-a0f52080-bf07-4948-8dde-0ff1db4c9f71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_screen.webp)
[Sync screen after save](https://cursor.com/agents/bc-a0f52080-bf07-4948-8dde-0ff1db4c9f71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_screen_saved.webp)

## Testing

- `uv run pytest` — 162 passed
- `uv run intervalssync check` — exit code 2 (no creds) / exit code 0 (demo `.env`)
- `uv run intervalssync-gui` (web mode) — loaded, saved credentials, rendered Sync screen


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f52080-bf07-4948-8dde-0ff1db4c9f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f52080-bf07-4948-8dde-0ff1db4c9f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

