### PR TITLE
feat(gui): add optional periodic auto-sync with notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,16 @@ jobs:
 
       # flet build apk auto-installs the Flutter/Android SDK + JDK on first run.
       # It picks up the FLET_ANDROID_SIGNING_* env vars set above when present.
+      # flet-android-notifications needs a post-template manifest/Gradle patch;
+      # the first build may fail at Gradle before that patch exists.
+      - name: Bootstrap Flutter project for Android
+        run: uv run flet build apk --yes --verbose --build-version "${{ env.APP_VERSION }}" || true
+
+      - name: Patch Android project for notifications / foreground service
+        run: |
+          test -d build/flutter
+          uv run flet-android-notifications-patch --project-root build/flutter
+
       - name: Build Android APK
         run: uv run flet build apk --yes --verbose --build-version "${{ env.APP_VERSION }}"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ src/intervalssync/
 - **`gui/secrets.py`** — async OS vault via `flet-secure-storage`.
 - **`gui/config.py`** — GUI JSON settings: `enable_igpsport` / `enable_bryton`, per-source usernames, shared sync options.
 - **`gui/sync_view.py`** — dispatches to `igpsport.core.sync` or `bryton.core.sync` per enabled source; workout upload is iGPSPORT-only.
+- **`gui/sync_runner.py`** — shared activity sync + overlap lock for manual Sync and auto-sync.
+- **`gui/auto_sync.py`** — optional periodic sync loop; Android FGS + OS notifications when rides upload.
 - **`cli/env.py`** — `.env` credential loading for the headless CLI.
 
 ## iGPSPORT API notes

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - Stores your credentials in the **OS secure vault** (Windows Credential Manager / macOS Keychain / Android Keystore), never in a file
 - Lets you know when a newer version is available
 - **Sync zones to iGPSPORT** — push FTP, LTHR, max HR, weight, and power/HR zones from intervals.icu into your iGPSPORT profile (Settings → iGPSPORT profile, or `intervalssync sync-zones`; the app prompts on launch when thresholds differ)
+- **Optional auto-sync** — periodically check for new rides and notify when uploads succeed (Settings → Auto-sync). On Android this uses a persistent notification while enabled; on desktop it only runs while the app is open. For unattended PC sync, prefer the [CLI](#cli--automation-ai-agents) with Task Scheduler / cron
 - **Headless CLI** — activity sync, workout upload, and iGPSPORT zone/threshold sync from the terminal, with JSON output and exit codes for automation and AI agents (see [CLI & automation](#cli--automation-ai-agents))
 - **China iGPSPORT region** — accounts on [app.igpsport.cn](https://app.igpsport.cn/login) use a separate API; choose **China** in Settings (or `INTERVALSSYNC_IGPSPORT_REGION=china` in the CLI)
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -159,6 +159,16 @@ Success example:
 
 Non-secret defaults in `intervalssync-cli` `config.json` (`platformdirs`). Secrets never go there.
 
+## GUI auto-sync
+
+Optional Settings toggle (`auto_sync_enabled`) polls enabled sources on an interval
+(`15` / `30` / `60` / `120` minutes) and notifies when new rides upload.
+
+- **Android:** foreground service sticky notification while enabled; force-stop still
+  stops sync. Shorter intervals use more battery.
+- **Desktop:** runs only while the GUI process is open. For unattended PC sync use
+  this CLI with Task Scheduler / cron (`intervalssync sync`).
+
 ## What it does
 
 ### Activity sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     # newer Python `flet` with an older Flutter client (or vice versa) breaks
     # the wire protocol and the packaged app stays on a black screen.
     "flet==0.86.1",
+    "flet-android-notifications>=0.10.0,<0.11",
     "flet-permission-handler==0.86.1",
     "flet-secure-storage==0.86.1",
     "garmin-fit-sdk>=21.208.0",
@@ -54,8 +55,15 @@ bundle_id = "io.github.jorgehuxley.intervalssync"
 # Android permissions baked into AndroidManifest.xml by `flet build apk`.
 # MANAGE_EXTERNAL_STORAGE ("all files access") + the legacy storage perms let
 # users opt into saving downloads to the public Downloads folder.
+# Auto-sync uses notifications + a foreground service (specialUse) so periodic
+# sync can continue while the UI is backgrounded.
 [tool.flet.android.permission]
 "android.permission.INTERNET" = true
 "android.permission.MANAGE_EXTERNAL_STORAGE" = true
 "android.permission.READ_EXTERNAL_STORAGE" = true
 "android.permission.WRITE_EXTERNAL_STORAGE" = true
+"android.permission.POST_NOTIFICATIONS" = true
+"android.permission.FOREGROUND_SERVICE" = true
+"android.permission.FOREGROUND_SERVICE_SPECIAL_USE" = true
+"android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" = true
+"android.permission.RECEIVE_BOOT_COMPLETED" = true

--- a/src/intervalssync/gui/app.py
+++ b/src/intervalssync/gui/app.py
@@ -14,6 +14,7 @@ from flet_secure_storage import SecureStorage
 from .. import __version__
 from . import config as config_module
 from . import secrets as secrets_module
+from .auto_sync import AutoSyncController
 from .update_check import RELEASES_PAGE, check_for_update
 from .settings_view import build_settings_view
 from .sync_view import build_sync_view
@@ -24,6 +25,7 @@ from . import theme
 
 _DESKTOP = {ft.PagePlatform.WINDOWS, ft.PagePlatform.MACOS, ft.PagePlatform.LINUX}
 _MOBILE = {ft.PagePlatform.ANDROID, ft.PagePlatform.ANDROID_TV, ft.PagePlatform.IOS}
+_ANDROID = {ft.PagePlatform.ANDROID, ft.PagePlatform.ANDROID_TV}
 _PERMISSION_HANDLER_PLATFORMS = {
     ft.PagePlatform.ANDROID,
     ft.PagePlatform.ANDROID_TV,
@@ -91,10 +93,25 @@ async def _app(page: ft.Page) -> None:
 
     store, storage = _secret_store_for_platform(page.platform)
     perms = PermissionHandler() if _supports_permission_handler(page.platform) else None
+    notifications = None
+    if page.platform in _ANDROID:
+        from flet_android_notifications import FletAndroidNotifications
+
+        notifications = FletAndroidNotifications()
     if storage is not None:
         page.services.append(storage)
     if perms is not None:
         page.services.append(perms)
+    if notifications is not None:
+        page.services.append(notifications)
+
+    auto_sync = AutoSyncController(
+        page,
+        config,
+        store,
+        notifications=notifications,
+        is_android=page.platform in _ANDROID,
+    )
 
     def _private_download_dir() -> str:
         base = os.getenv("FLET_APP_STORAGE_DATA") or tempfile.gettempdir()
@@ -272,6 +289,7 @@ async def _app(page: ft.Page) -> None:
                 perms=perms,
                 apply_download_location=apply_download_location,
                 on_profile_sync_check=on_profile_sync_check,
+                on_auto_sync_changed=auto_sync.apply,
             )
         )
         header_slot.content = _header()
@@ -301,6 +319,12 @@ async def _app(page: ft.Page) -> None:
                     theme.SPACE_MD, theme.SPACE_SM, theme.SPACE_MD, theme.SPACE_SM
                 ),
             )
+
+    def on_lifecycle(e: ft.AppLifecycleStateChangeEvent) -> None:
+        if e.state == ft.AppLifecycleState.RESUME:
+            page.run_task(auto_sync.on_app_resume)
+
+    page.on_app_lifecycle_state_change = on_lifecycle
 
     page.add(
         ft.SafeArea(
@@ -342,6 +366,7 @@ async def _app(page: ft.Page) -> None:
 
     page.run_task(auto_check_updates)
     page.run_task(auto_check_profile_sync)
+    page.run_task(auto_sync.apply)
 
 
 def main() -> None:

--- a/src/intervalssync/gui/app.py
+++ b/src/intervalssync/gui/app.py
@@ -339,9 +339,9 @@ async def _app(page: ft.Page) -> None:
                         content=body,
                         expand=True,
                         padding=ft.Padding(
-                            theme.SPACE_LG,
+                            theme.SPACE_MD if is_mobile else theme.SPACE_LG,
                             theme.SPACE_MD,
-                            theme.SPACE_LG,
+                            theme.SPACE_MD if is_mobile else theme.SPACE_LG,
                             theme.SPACE_LG if not is_mobile else theme.SPACE_MD,
                         ),
                     ),

--- a/src/intervalssync/gui/auto_sync.py
+++ b/src/intervalssync/gui/auto_sync.py
@@ -1,0 +1,181 @@
+"""Optional periodic activity auto-sync with notifications."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+import flet as ft
+
+from . import config as config_module
+from . import secrets as secrets_module
+from . import support_gamification
+from . import sync_runner
+
+if TYPE_CHECKING:
+    from flet_android_notifications import FletAndroidNotifications
+
+_FGS_NOTIFICATION_ID = 1001
+_UPLOAD_NOTIFICATION_ID = 1002
+_CHANNEL_ID = "intervalssync_auto_sync"
+_CHANNEL_NAME = "Auto-sync"
+_CHANNEL_DESCRIPTION = "Background activity sync for Intervals Sync"
+# Skip resume-triggered sync if a run finished within this many seconds.
+_RESUME_MIN_GAP_SECONDS = 5 * 60
+
+
+class AutoSyncController:
+    """Starts/stops a periodic sync loop based on AppConfig.auto_sync_*."""
+
+    def __init__(
+        self,
+        page: ft.Page,
+        config: config_module.AppConfig,
+        store: secrets_module.SecretStore,
+        *,
+        notifications: FletAndroidNotifications | None = None,
+        is_android: bool = False,
+    ) -> None:
+        self._page = page
+        self._config = config
+        self._store = store
+        self._notifications = notifications
+        self._is_android = is_android
+        self._generation = 0
+        self._loop_task: asyncio.Task[None] | None = None
+        self._fgs_active = False
+        self._last_sync_finished_at = 0.0
+
+    async def apply(self) -> None:
+        """Start or stop the loop to match current config."""
+        self._generation += 1
+        generation = self._generation
+        if self._loop_task is not None and not self._loop_task.done():
+            self._loop_task.cancel()
+            try:
+                await self._loop_task
+            except asyncio.CancelledError:
+                pass
+            self._loop_task = None
+
+        if not self._config.auto_sync_enabled:
+            await self._stop_foreground_service()
+            return
+
+        interval = config_module.clamp_auto_sync_interval(
+            self._config.auto_sync_interval_minutes
+        )
+        self._config.auto_sync_interval_minutes = interval
+        await self._start_foreground_service()
+        self._loop_task = asyncio.create_task(
+            self._loop(generation, interval),
+            name="intervalssync-auto-sync",
+        )
+
+    async def on_app_resume(self) -> None:
+        """Run a sync soon after the app returns to the foreground."""
+        if not self._config.auto_sync_enabled:
+            return
+        if time.monotonic() - self._last_sync_finished_at < _RESUME_MIN_GAP_SECONDS:
+            return
+        await self._run_once()
+
+    async def _loop(self, generation: int, interval_minutes: int) -> None:
+        try:
+            await self._run_once()
+            while generation == self._generation:
+                await asyncio.sleep(interval_minutes * 60)
+                if generation != self._generation:
+                    break
+                await self._run_once()
+        except asyncio.CancelledError:
+            raise
+
+    async def _run_once(self) -> None:
+        (
+            igp_password,
+            bryton_password,
+            api_key,
+            dropbox_refresh_token,
+        ) = await sync_runner.load_sync_secrets(self._store)
+
+        outcome = await asyncio.to_thread(
+            sync_runner.run_enabled_activity_sync,
+            self._config,
+            igp_password=igp_password,
+            bryton_password=bryton_password,
+            api_key=api_key,
+            dropbox_refresh_token=dropbox_refresh_token,
+        )
+        self._last_sync_finished_at = time.monotonic()
+        if outcome.busy:
+            return
+        if outcome.uploaded <= 0:
+            return
+
+        support_gamification.record_uploads(
+            self._config, activities=outcome.uploaded
+        )
+        await self._notify_uploads(outcome.uploaded)
+
+    async def _notify_uploads(self, uploaded: int) -> None:
+        ride_word = "ride" if uploaded == 1 else "rides"
+        title = "Intervals Sync"
+        body = f"Uploaded {uploaded} {ride_word} to intervals.icu"
+
+        if self._is_android and self._notifications is not None:
+            try:
+                await self._notifications.show_notification(
+                    notification_id=_UPLOAD_NOTIFICATION_ID,
+                    title=title,
+                    body=body,
+                    channel_id=_CHANNEL_ID,
+                    channel_name=_CHANNEL_NAME,
+                    channel_description=_CHANNEL_DESCRIPTION,
+                    importance="default",
+                    play_sound=True,
+                    enable_vibration=True,
+                    auto_cancel=True,
+                )
+                return
+            except Exception:  # noqa: BLE001 — fall back to in-app snack
+                pass
+
+        self._page.show_dialog(ft.SnackBar(ft.Text(body)))
+        self._page.update()
+
+    async def _start_foreground_service(self) -> None:
+        if not self._is_android or self._notifications is None or self._fgs_active:
+            return
+        interval = self._config.auto_sync_interval_minutes
+        try:
+            await self._notifications.request_permissions()
+            await self._notifications.start_foreground_service(
+                notification_id=_FGS_NOTIFICATION_ID,
+                title="Intervals Sync — auto-sync on",
+                body=f"Checking for new rides every {interval} minutes",
+                foreground_service_types=["special_use"],
+                channel_id=_CHANNEL_ID,
+                channel_name=_CHANNEL_NAME,
+                channel_description=_CHANNEL_DESCRIPTION,
+                importance="low",
+                play_sound=False,
+                enable_vibration=False,
+                ongoing=True,
+                silent=True,
+                auto_cancel=False,
+            )
+            self._fgs_active = True
+        except Exception:  # noqa: BLE001 — FGS is best-effort
+            self._fgs_active = False
+
+    async def _stop_foreground_service(self) -> None:
+        if not self._is_android or self._notifications is None or not self._fgs_active:
+            self._fgs_active = False
+            return
+        try:
+            await self._notifications.stop_foreground_service()
+        except Exception:  # noqa: BLE001 — ignore stop failures
+            pass
+        self._fgs_active = False

--- a/src/intervalssync/gui/config.py
+++ b/src/intervalssync/gui/config.py
@@ -18,9 +18,23 @@ APP_NAME = "intervalssync"
 CONFIG_DIR = Path(user_config_dir(APP_NAME, appauthor=False))
 CONFIG_PATH = CONFIG_DIR / "config.json"
 
+# Allowed auto-sync poll intervals (minutes). Shorter = more battery use.
+AUTO_SYNC_INTERVALS: tuple[int, ...] = (15, 30, 60, 120)
+
 
 def _default_download_dir() -> str:
     return str(Path(user_downloads_dir()) / "intervalssync-fit")
+
+
+def clamp_auto_sync_interval(minutes: int) -> int:
+    """Snap to the nearest allowed auto-sync interval."""
+    try:
+        value = int(minutes)
+    except (TypeError, ValueError):
+        return 60
+    if value in AUTO_SYNC_INTERVALS:
+        return value
+    return min(AUTO_SYNC_INTERVALS, key=lambda allowed: abs(allowed - value))
 
 
 @dataclass
@@ -61,6 +75,9 @@ class AppConfig:
     profile_sync_declined_fingerprint: str = ""
     # Prompt on launch when FTP, LTHR, max HR, or weight differ from intervals.icu.
     profile_sync_check_on_launch: bool = True
+    # Periodic activity sync while the app (or Android FGS) stays alive.
+    auto_sync_enabled: bool = False
+    auto_sync_interval_minutes: int = 60
     # Lifetime sync stats (GUI gamification).
     lifetime_activities_uploaded: int = 0
     lifetime_workouts_uploaded: int = 0
@@ -88,6 +105,9 @@ def load() -> AppConfig:
     if activity_source == "bryton":
         cfg.enable_bryton = True
         cfg.enable_igpsport = False
+    cfg.auto_sync_interval_minutes = clamp_auto_sync_interval(
+        cfg.auto_sync_interval_minutes
+    )
     if not cfg.stats_seeded:
         cfg.lifetime_workouts_uploaded = len(cfg.uploaded_workouts) + len(
             cfg.uploaded_bryton_workouts

--- a/src/intervalssync/gui/settings_view.py
+++ b/src/intervalssync/gui/settings_view.py
@@ -53,9 +53,18 @@ async def build_settings_view(
 
     def _input_field(**kwargs: object) -> ft.TextField:
         kwargs.setdefault("border_radius", theme.RADIUS_SM)
+        # Material TextField helpers default to one line and ellipsize on narrow screens.
+        kwargs.setdefault("helper_max_lines", 4)
+        # Fill the settings column width so attached helpers are not clipped early.
+        kwargs.setdefault("width", float("inf"))
         if is_mobile:
             kwargs.setdefault("text_size", 14)
         return ft.TextField(**kwargs)
+
+    def _dropdown(**kwargs: object) -> ft.Dropdown:
+        kwargs.setdefault("border_radius", theme.RADIUS_SM)
+        kwargs.setdefault("width", float("inf"))
+        return ft.Dropdown(**kwargs)
 
     enable_igpsport = ft.Switch(
         label="Enable iGPSPORT",
@@ -65,7 +74,7 @@ async def build_settings_view(
     igp_region_value = (
         config.igp_region if config.igp_region in ("international", "china") else "international"
     )
-    igp_region = ft.Dropdown(
+    igp_region = _dropdown(
         label="iGPSPORT region",
         value=igp_region_value,
         options=[
@@ -138,10 +147,9 @@ async def build_settings_view(
         ),
     )
 
-    activity_type = ft.Dropdown(
+    activity_type = _dropdown(
         label="Activity type on intervals.icu",
         value=config.activity_type,
-        border_radius=theme.RADIUS_SM,
         options=[
             ft.dropdown.Option(key="", text="Don't change (leave as uploaded)"),
             *(
@@ -167,23 +175,24 @@ async def build_settings_view(
         ft.PagePlatform.ANDROID,
         ft.PagePlatform.ANDROID_TV,
     )
-    auto_sync_interval_value = str(
-        config_module.clamp_auto_sync_interval(config.auto_sync_interval_minutes)
+    # TextField (not Dropdown) so helper_max_lines can wrap like other settings helpers.
+    selected_auto_sync_minutes = config_module.clamp_auto_sync_interval(
+        config.auto_sync_interval_minutes
     )
+
+    def _auto_sync_interval_label(minutes: int) -> str:
+        return f"Every {minutes} minutes"
+
     auto_sync_enabled = ft.Switch(
         label="Auto-sync in background",
         value=config.auto_sync_enabled,
         active_color=colors["accent"],
     )
-    auto_sync_interval = ft.Dropdown(
+    auto_sync_interval = _input_field(
         label="Auto-sync interval",
-        value=auto_sync_interval_value,
-        border_radius=theme.RADIUS_SM,
-        options=[
-            ft.dropdown.Option(str(minutes), f"Every {minutes} minutes")
-            for minutes in config_module.AUTO_SYNC_INTERVALS
-        ],
-        helper_text=(
+        value=_auto_sync_interval_label(selected_auto_sync_minutes),
+        read_only=True,
+        helper=(
             "Shorter intervals use more battery. On Android a persistent "
             "notification keeps sync running while enabled; force-stopping "
             "the app still stops auto-sync. On desktop, sync only runs while "
@@ -194,6 +203,24 @@ async def build_settings_view(
                 "the app is open (use the CLI + Task Scheduler for unattended PC sync)."
             )
         ),
+    )
+
+    def _select_auto_sync_interval(minutes: int) -> None:
+        nonlocal selected_auto_sync_minutes
+        selected_auto_sync_minutes = minutes
+        auto_sync_interval.value = _auto_sync_interval_label(minutes)
+        page.update()
+
+    auto_sync_interval.suffix = ft.PopupMenuButton(
+        icon=ft.Icons.ARROW_DROP_DOWN,
+        tooltip="Choose interval",
+        items=[
+            ft.PopupMenuItem(
+                content=ft.Text(_auto_sync_interval_label(minutes)),
+                on_click=lambda _e, m=minutes: _select_auto_sync_interval(m),
+            )
+            for minutes in config_module.AUTO_SYNC_INTERVALS
+        ],
     )
 
     upload_dropbox = ft.Switch(
@@ -549,10 +576,12 @@ async def build_settings_view(
 
     igp_credentials = ft.Column(
         spacing=theme.SPACE_SM,
+        horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
         controls=[igp_region, igp_user, igp_password],
     )
     bryton_credentials = ft.Column(
         spacing=theme.SPACE_SM,
+        horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
         controls=[bryton_user, bryton_password],
     )
     workout_sync_section = ft.Container(
@@ -651,13 +680,12 @@ async def build_settings_view(
         config.upload_dropbox = bool(upload_dropbox.value)
 
         want_auto_sync = bool(auto_sync_enabled.value)
-        try:
-            config.auto_sync_interval_minutes = config_module.clamp_auto_sync_interval(
-                int(auto_sync_interval.value or "60")
-            )
-        except (TypeError, ValueError):
-            config.auto_sync_interval_minutes = 60
-        auto_sync_interval.value = str(config.auto_sync_interval_minutes)
+        config.auto_sync_interval_minutes = config_module.clamp_auto_sync_interval(
+            selected_auto_sync_minutes
+        )
+        auto_sync_interval.value = _auto_sync_interval_label(
+            config.auto_sync_interval_minutes
+        )
 
         message = "Saved securely to your system credential store."
         if want_auto_sync and is_android and perms is not None:
@@ -738,6 +766,7 @@ async def build_settings_view(
 
     return ft.Column(
         spacing=theme.SPACE_LG,
+        horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
         controls=[
             ft.Column(
                 spacing=theme.SPACE_SM,

--- a/src/intervalssync/gui/settings_view.py
+++ b/src/intervalssync/gui/settings_view.py
@@ -39,6 +39,7 @@ async def build_settings_view(
     perms: PermissionHandler | None = None,
     apply_download_location: Callable[[], Awaitable[None]] | None = None,
     on_profile_sync_check: Callable[[], Awaitable[None]] | None = None,
+    on_auto_sync_changed: Callable[[], Awaitable[None]] | None = None,
 ) -> ft.Control:
     colors = theme.palette(page)
 
@@ -160,6 +161,39 @@ async def build_settings_view(
         label="Force re-sync (re-download even if already uploaded)",
         value=config.force_resync,
         active_color=colors["accent"],
+    )
+
+    is_android = page.platform in (
+        ft.PagePlatform.ANDROID,
+        ft.PagePlatform.ANDROID_TV,
+    )
+    auto_sync_interval_value = str(
+        config_module.clamp_auto_sync_interval(config.auto_sync_interval_minutes)
+    )
+    auto_sync_enabled = ft.Switch(
+        label="Auto-sync in background",
+        value=config.auto_sync_enabled,
+        active_color=colors["accent"],
+    )
+    auto_sync_interval = ft.Dropdown(
+        label="Auto-sync interval",
+        value=auto_sync_interval_value,
+        border_radius=theme.RADIUS_SM,
+        options=[
+            ft.dropdown.Option(str(minutes), f"Every {minutes} minutes")
+            for minutes in config_module.AUTO_SYNC_INTERVALS
+        ],
+        helper_text=(
+            "Shorter intervals use more battery. On Android a persistent "
+            "notification keeps sync running while enabled; force-stopping "
+            "the app still stops auto-sync. On desktop, sync only runs while "
+            "the app is open."
+            if is_android
+            else (
+                "Shorter intervals use more battery. Auto-sync runs only while "
+                "the app is open (use the CLI + Task Scheduler for unattended PC sync)."
+            )
+        ),
     )
 
     upload_dropbox = ft.Switch(
@@ -616,7 +650,33 @@ async def build_settings_view(
         config.dropbox_date_filenames = bool(dropbox_date_filenames_switch.value)
         config.upload_dropbox = bool(upload_dropbox.value)
 
+        want_auto_sync = bool(auto_sync_enabled.value)
+        try:
+            config.auto_sync_interval_minutes = config_module.clamp_auto_sync_interval(
+                int(auto_sync_interval.value or "60")
+            )
+        except (TypeError, ValueError):
+            config.auto_sync_interval_minutes = 60
+        auto_sync_interval.value = str(config.auto_sync_interval_minutes)
+
         message = "Saved securely to your system credential store."
+        if want_auto_sync and is_android and perms is not None:
+            notify_status = await perms.request(Permission.NOTIFICATION)
+            battery_status = await perms.request(Permission.IGNORE_BATTERY_OPTIMIZATIONS)
+            if notify_status != PermissionStatus.GRANTED:
+                want_auto_sync = False
+                auto_sync_enabled.value = False
+                message = (
+                    "Saved, but auto-sync stayed off — notification permission "
+                    "is required on Android."
+                )
+            elif battery_status != PermissionStatus.GRANTED:
+                message = (
+                    "Saved with auto-sync on. For best results, allow unrestricted "
+                    "battery use for Intervals Sync in system settings."
+                )
+        config.auto_sync_enabled = want_auto_sync
+
         if config.upload_dropbox and not dropbox_app_key:
             config.upload_dropbox = False
             upload_dropbox.value = False
@@ -655,6 +715,8 @@ async def build_settings_view(
 
         page.show_dialog(ft.SnackBar(ft.Text(message)))
         await on_saved()
+        if on_auto_sync_changed is not None:
+            await on_auto_sync_changed()
         if on_profile_sync_check is not None and config.enable_igpsport:
             await on_profile_sync_check()
 
@@ -705,6 +767,8 @@ async def build_settings_view(
                 activity_type,
                 delete_after_upload,
                 force_resync,
+                auto_sync_enabled,
+                auto_sync_interval,
                 workout_sync_section,
             ),
             profile_sync_section,

--- a/src/intervalssync/gui/sync_runner.py
+++ b/src/intervalssync/gui/sync_runner.py
@@ -1,0 +1,187 @@
+"""Shared activity-sync helpers for the GUI (manual Sync + auto-sync)."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from ..bryton.core import SyncConfig as BrytonSyncConfig, sync as bryton_sync
+from ..bryton.exceptions import BrytonSyncError
+from ..dropbox_client import get_dropbox_app_key
+from ..igpsport.core import SyncConfig as IgpSyncConfig, SyncError, sync as igpsport_sync
+from . import config as config_module
+from . import secrets as secrets_module
+
+Progress = Callable[[str], None]
+
+_sync_lock = threading.Lock()
+
+
+@dataclass
+class ActivitySyncOutcome:
+    uploaded: int = 0
+    uploaded_dropbox: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+    # True when another sync held the lock (manual or auto).
+    busy: bool = False
+
+
+def try_begin_sync() -> bool:
+    """Acquire the global sync lock without blocking."""
+    return _sync_lock.acquire(blocking=False)
+
+
+def end_sync() -> None:
+    """Release the global sync lock."""
+    _sync_lock.release()
+
+
+def igp_sync_config(
+    config: config_module.AppConfig,
+    *,
+    igp_password: str,
+    api_key: str | None,
+    dropbox_refresh_token: str | None,
+    dropbox_app_key: str | None,
+) -> IgpSyncConfig:
+    return IgpSyncConfig(
+        igp_user=config.igp_user,
+        igp_password=igp_password,
+        igp_region=config.igp_region,
+        intervals_api_key=api_key,
+        dropbox_refresh_token=dropbox_refresh_token,
+        dropbox_app_key=dropbox_app_key,
+        max_activities=config.max_activities,
+        download_dir=config.download_dir,
+        delete_after_upload=config.delete_after_upload,
+        force_resync=config.force_resync,
+        activity_type=config.activity_type,
+        list_activities=config.step_list_activities,
+        get_download_url=config.step_get_download_url,
+        download_fit=config.step_download_fit,
+        upload_intervals=config.step_upload_intervals,
+        upload_dropbox=config.upload_dropbox,
+        dropbox_folder=config.dropbox_folder,
+        dropbox_date_filenames=config.dropbox_date_filenames,
+    )
+
+
+def bryton_sync_config(
+    config: config_module.AppConfig,
+    *,
+    bryton_password: str,
+    api_key: str | None,
+    dropbox_refresh_token: str | None,
+    dropbox_app_key: str | None,
+) -> BrytonSyncConfig:
+    return BrytonSyncConfig(
+        bryton_email=config.bryton_user,
+        bryton_password=bryton_password,
+        intervals_api_key=api_key,
+        dropbox_refresh_token=dropbox_refresh_token,
+        dropbox_app_key=dropbox_app_key,
+        max_activities=config.max_activities,
+        download_dir=Path(config.download_dir),
+        delete_after_upload=config.delete_after_upload,
+        force_resync=config.force_resync,
+        activity_type=config.activity_type,
+        list_activities=config.step_list_activities,
+        download_fit=config.step_download_fit,
+        upload_intervals=config.step_upload_intervals,
+        upload_dropbox=config.upload_dropbox,
+        dropbox_folder=config.dropbox_folder,
+        dropbox_date_filenames=config.dropbox_date_filenames,
+    )
+
+
+def run_enabled_activity_sync(
+    config: config_module.AppConfig,
+    *,
+    igp_password: str | None,
+    bryton_password: str | None,
+    api_key: str | None,
+    dropbox_refresh_token: str | None,
+    dropbox_app_key: str | None = None,
+    progress: Progress | None = None,
+) -> ActivitySyncOutcome:
+    """Sync all enabled sources. Skips if another sync is already running."""
+    if not try_begin_sync():
+        return ActivitySyncOutcome(busy=True)
+
+    report = progress or (lambda _msg: None)
+    outcome = ActivitySyncOutcome()
+    app_key = dropbox_app_key if dropbox_app_key is not None else get_dropbox_app_key()
+
+    try:
+        if config.enable_igpsport:
+            if not config.igp_user or not igp_password:
+                outcome.errors.append("iGPSPORT credentials missing")
+            else:
+                report("Auto-sync: iGPSPORT…")
+                try:
+                    result = igpsport_sync(
+                        igp_sync_config(
+                            config,
+                            igp_password=igp_password,
+                            api_key=api_key,
+                            dropbox_refresh_token=dropbox_refresh_token,
+                            dropbox_app_key=app_key,
+                        ),
+                        progress=report,
+                    )
+                    outcome.uploaded += result.uploaded
+                    outcome.uploaded_dropbox += result.uploaded_dropbox
+                    outcome.skipped += result.skipped
+                    outcome.failed += result.failed
+                except SyncError as exc:
+                    outcome.errors.append(str(exc))
+                    report(f"✗ iGPSPORT: {exc}")
+                except Exception as exc:  # noqa: BLE001 — surface unexpected failures
+                    outcome.errors.append(str(exc))
+                    report(f"✗ iGPSPORT unexpected error: {exc}")
+
+        if config.enable_bryton:
+            if not config.bryton_user or not bryton_password:
+                outcome.errors.append("Bryton credentials missing")
+            else:
+                report("Auto-sync: Bryton…")
+                try:
+                    result = bryton_sync(
+                        bryton_sync_config(
+                            config,
+                            bryton_password=bryton_password,
+                            api_key=api_key,
+                            dropbox_refresh_token=dropbox_refresh_token,
+                            dropbox_app_key=app_key,
+                        ),
+                        progress=report,
+                    )
+                    outcome.uploaded += result.uploaded
+                    outcome.uploaded_dropbox += result.uploaded_dropbox
+                    outcome.skipped += result.skipped
+                    outcome.failed += result.failed
+                except BrytonSyncError as exc:
+                    outcome.errors.append(str(exc))
+                    report(f"✗ Bryton: {exc}")
+                except Exception as exc:  # noqa: BLE001 — surface unexpected failures
+                    outcome.errors.append(str(exc))
+                    report(f"✗ Bryton unexpected error: {exc}")
+    finally:
+        end_sync()
+
+    return outcome
+
+
+async def load_sync_secrets(
+    store: secrets_module.SecretStore,
+) -> tuple[str | None, str | None, str | None, str | None]:
+    """Return (igp_password, bryton_password, api_key, dropbox_refresh_token)."""
+    igp_password = await store.get(secrets_module.IGP_PASSWORD)
+    bryton_password = await store.get(secrets_module.BRYTON_PASSWORD)
+    api_key = await store.get(secrets_module.INTERVALS_API_KEY)
+    dropbox_refresh_token = await store.get(secrets_module.DROPBOX_REFRESH_TOKEN)
+    return igp_password, bryton_password, api_key, dropbox_refresh_token

--- a/src/intervalssync/gui/sync_view.py
+++ b/src/intervalssync/gui/sync_view.py
@@ -2,23 +2,22 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import flet as ft
 
 from . import config as config_module
 from . import secrets as secrets_module
-from ..bryton.core import SyncConfig as BrytonSyncConfig, sync as bryton_sync
+from ..bryton.core import sync as bryton_sync
 from ..bryton.exceptions import BrytonSyncError
 from ..bryton.workout import (
     BrytonWorkoutUploadConfig,
     apply_uploaded_bryton_workout_map,
     upload_workouts as bryton_upload_workouts,
 )
-from ..igpsport.core import SyncConfig as IgpSyncConfig, SyncError, sync as igpsport_sync
+from ..igpsport.core import SyncError, sync as igpsport_sync
 from ..dropbox_client import get_dropbox_app_key
 from ..igpsport.workout import WorkoutUploadConfig, apply_uploaded_workout_map, upload_workouts
 from . import support_gamification
+from . import sync_runner
 from . import theme
 
 
@@ -186,30 +185,18 @@ def build_sync_view(
         dropbox_refresh_token: str | None,
         dropbox_app_key: str | None,
     ) -> None:
-        sync_config = IgpSyncConfig(
-            igp_user=config.igp_user,
-            igp_password=igp_password,
-            igp_region=config.igp_region,
-            intervals_api_key=api_key,
-            dropbox_refresh_token=dropbox_refresh_token,
-            dropbox_app_key=dropbox_app_key,
-            max_activities=config.max_activities,
-            download_dir=config.download_dir,
-            delete_after_upload=config.delete_after_upload,
-            force_resync=config.force_resync,
-            activity_type=config.activity_type,
-            list_activities=config.step_list_activities,
-            get_download_url=config.step_get_download_url,
-            download_fit=config.step_download_fit,
-            upload_intervals=config.step_upload_intervals,
-            upload_dropbox=config.upload_dropbox,
-            dropbox_folder=config.dropbox_folder,
-            dropbox_date_filenames=config.dropbox_date_filenames,
-        )
-
         uploaded_count = 0
         try:
-            result = igpsport_sync(sync_config, progress=append_log)
+            result = igpsport_sync(
+                sync_runner.igp_sync_config(
+                    config,
+                    igp_password=igp_password,
+                    api_key=api_key,
+                    dropbox_refresh_token=dropbox_refresh_token,
+                    dropbox_app_key=dropbox_app_key,
+                ),
+                progress=append_log,
+            )
             uploaded_count = result.uploaded
             append_log(
                 f"\nDone — intervals uploaded {result.uploaded}, "
@@ -223,6 +210,7 @@ def build_sync_view(
         except Exception as exc:  # noqa: BLE001 — surface any failure to the user
             append_log(f"✗ Unexpected error: {exc}")
         finally:
+            sync_runner.end_sync()
             if uploaded_count > 0:
                 _on_sync_complete(activities=uploaded_count)
             progress.visible = False
@@ -235,28 +223,18 @@ def build_sync_view(
         dropbox_refresh_token: str | None,
         dropbox_app_key: str | None,
     ) -> None:
-        sync_config = BrytonSyncConfig(
-            bryton_email=config.bryton_user,
-            bryton_password=bryton_password,
-            intervals_api_key=api_key,
-            dropbox_refresh_token=dropbox_refresh_token,
-            dropbox_app_key=dropbox_app_key,
-            max_activities=config.max_activities,
-            download_dir=Path(config.download_dir),
-            delete_after_upload=config.delete_after_upload,
-            force_resync=config.force_resync,
-            activity_type=config.activity_type,
-            list_activities=config.step_list_activities,
-            download_fit=config.step_download_fit,
-            upload_intervals=config.step_upload_intervals,
-            upload_dropbox=config.upload_dropbox,
-            dropbox_folder=config.dropbox_folder,
-            dropbox_date_filenames=config.dropbox_date_filenames,
-        )
-
         uploaded_count = 0
         try:
-            result = bryton_sync(sync_config, progress=append_log)
+            result = bryton_sync(
+                sync_runner.bryton_sync_config(
+                    config,
+                    bryton_password=bryton_password,
+                    api_key=api_key,
+                    dropbox_refresh_token=dropbox_refresh_token,
+                    dropbox_app_key=dropbox_app_key,
+                ),
+                progress=append_log,
+            )
             uploaded_count = result.uploaded
             append_log(
                 f"\nDone — intervals uploaded {result.uploaded}, "
@@ -270,6 +248,7 @@ def build_sync_view(
         except Exception as exc:  # noqa: BLE001 — surface any failure to the user
             append_log(f"✗ Unexpected error: {exc}")
         finally:
+            sync_runner.end_sync()
             if uploaded_count > 0:
                 _on_sync_complete(activities=uploaded_count)
             progress.visible = False
@@ -348,6 +327,11 @@ def build_sync_view(
         if not config.igp_user or not igp_password:
             page.show_dialog(ft.SnackBar(ft.Text("Add your iGPSPORT credentials in Settings first.")))
             return
+        if not sync_runner.try_begin_sync():
+            page.show_dialog(
+                ft.SnackBar(ft.Text("A sync is already running. Try again in a moment."))
+            )
+            return
         api_key = await store.get(secrets_module.INTERVALS_API_KEY)
         dropbox_refresh_token = await store.get(secrets_module.DROPBOX_REFRESH_TOKEN)
         dropbox_app_key = get_dropbox_app_key()
@@ -368,6 +352,11 @@ def build_sync_view(
         bryton_password = await store.get(secrets_module.BRYTON_PASSWORD)
         if not config.bryton_user or not bryton_password:
             page.show_dialog(ft.SnackBar(ft.Text("Add your Bryton credentials in Settings first.")))
+            return
+        if not sync_runner.try_begin_sync():
+            page.show_dialog(
+                ft.SnackBar(ft.Text("A sync is already running. Try again in a moment."))
+            )
             return
         api_key = await store.get(secrets_module.INTERVALS_API_KEY)
         dropbox_refresh_token = await store.get(secrets_module.DROPBOX_REFRESH_TOKEN)

--- a/src/intervalssync/gui/theme.py
+++ b/src/intervalssync/gui/theme.py
@@ -204,12 +204,15 @@ def settings_section(
             ft.Text(subtitle, size=13, color=colors["text_muted"])
         )
     header.append(ft.Container(height=SPACE_SM))
+    # Tighter side padding on phones so fields/helpers get more horizontal room.
+    side = SPACE_MD if is_mobile(page) else SPACE_LG
     return ft.Container(
         content=ft.Column(
             spacing=SPACE_MD,
+            horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
             controls=[*header, *controls],
         ),
-        padding=ft.Padding(SPACE_LG, SPACE_LG, SPACE_LG, SPACE_LG),
+        padding=ft.Padding(side, SPACE_LG, side, SPACE_LG),
         bgcolor=colors["surface"],
         border=ft.Border.all(1, colors["border"]),
         border_radius=RADIUS_MD,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,12 +22,23 @@ def test_defaults():
     assert cfg.uploaded_workouts == {}
     assert cfg.uploaded_bryton_workouts == {}
     assert cfg.workout_days_ahead == 1
+    assert cfg.auto_sync_enabled is False
+    assert cfg.auto_sync_interval_minutes == 60
     assert cfg.lifetime_activities_uploaded == 0
     assert cfg.lifetime_workouts_uploaded == 0
     assert cfg.celebrated_milestones == []
     assert cfg.stats_seeded is False
     assert config_module.total_uploads(cfg) == 0
     assert config_module.any_source_enabled(cfg) is True
+
+
+def test_clamp_auto_sync_interval():
+    assert config_module.clamp_auto_sync_interval(60) == 60
+    assert config_module.clamp_auto_sync_interval(15) == 15
+    assert config_module.clamp_auto_sync_interval(20) == 15
+    assert config_module.clamp_auto_sync_interval(90) == 60
+    assert config_module.clamp_auto_sync_interval(200) == 120
+    assert config_module.clamp_auto_sync_interval("nope") == 60  # type: ignore[arg-type]
 
 
 def test_save_and_load_roundtrip(tmp_path, monkeypatch):
@@ -170,3 +181,33 @@ def test_save_and_load_igp_region(tmp_path, monkeypatch):
     loaded = config_module.load()
     assert loaded.igp_region == "china"
     assert loaded.igp_user == "13800000000"
+
+
+def test_save_and_load_auto_sync(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", path)
+
+    cfg = config_module.AppConfig(
+        auto_sync_enabled=True,
+        auto_sync_interval_minutes=30,
+    )
+    config_module.save(cfg)
+
+    loaded = config_module.load()
+    assert loaded.auto_sync_enabled is True
+    assert loaded.auto_sync_interval_minutes == 30
+
+
+def test_load_clamps_auto_sync_interval(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    path.write_text(
+        '{"auto_sync_enabled": true, "auto_sync_interval_minutes": 17}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_module, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", path)
+
+    loaded = config_module.load()
+    assert loaded.auto_sync_enabled is True
+    assert loaded.auto_sync_interval_minutes == 15

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -1,0 +1,68 @@
+"""Tests for the shared GUI activity sync runner."""
+
+from __future__ import annotations
+
+from intervalssync.gui import config as config_module
+from intervalssync.gui import sync_runner
+
+
+def test_try_begin_sync_is_exclusive():
+    assert sync_runner.try_begin_sync() is True
+    try:
+        assert sync_runner.try_begin_sync() is False
+    finally:
+        sync_runner.end_sync()
+    assert sync_runner.try_begin_sync() is True
+    sync_runner.end_sync()
+
+
+def test_run_enabled_activity_sync_reports_busy(monkeypatch):
+    assert sync_runner.try_begin_sync() is True
+    try:
+        outcome = sync_runner.run_enabled_activity_sync(
+            config_module.AppConfig(enable_igpsport=False, enable_bryton=False),
+            igp_password=None,
+            bryton_password=None,
+            api_key=None,
+            dropbox_refresh_token=None,
+        )
+        assert outcome.busy is True
+    finally:
+        sync_runner.end_sync()
+
+
+def test_run_enabled_activity_sync_igpsport(monkeypatch):
+    calls: list[str] = []
+
+    class FakeResult:
+        uploaded = 2
+        uploaded_dropbox = 0
+        skipped = 1
+        failed = 0
+
+    def fake_sync(config, progress=None):
+        calls.append(config.igp_user)
+        if progress:
+            progress("ok")
+        return FakeResult()
+
+    monkeypatch.setattr(sync_runner, "igpsport_sync", fake_sync)
+
+    outcome = sync_runner.run_enabled_activity_sync(
+        config_module.AppConfig(
+            enable_igpsport=True,
+            enable_bryton=False,
+            igp_user="me@example.com",
+        ),
+        igp_password="secret",
+        bryton_password=None,
+        api_key="key",
+        dropbox_refresh_token=None,
+    )
+    assert outcome.busy is False
+    assert outcome.uploaded == 2
+    assert outcome.skipped == 1
+    assert calls == ["me@example.com"]
+    # Lock must be released for subsequent runs.
+    assert sync_runner.try_begin_sync() is True
+    sync_runner.end_sync()

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,18 @@ wheels = [
 ]
 
 [[package]]
+name = "flet-android-notifications"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/f5/24d9ca84f1046cc69f6c28e3669c5b88de43ccc0680ade407c8a6103ca53/flet_android_notifications-0.10.0.tar.gz", hash = "sha256:281a233fb62c443950a9436404c99e83fbb9603f3d79f8f84ef7ce8a5f95dd87", size = 26113, upload-time = "2026-07-21T21:08:59.28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/63/e1c1a03f5e107388340f695def3a50a614207b628c48448617e76b53caa8/flet_android_notifications-0.10.0-py3-none-any.whl", hash = "sha256:ae31781f9c806478adf35c8835ec99d10449cb2cde1b8f49b56e2438fb8c9288", size = 28672, upload-time = "2026-07-21T21:08:58.057Z" },
+]
+
+[[package]]
 name = "flet-permission-handler"
 version = "0.86.1"
 source = { registry = "https://pypi.org/simple" }
@@ -181,6 +193,7 @@ source = { editable = "." }
 dependencies = [
     { name = "dropbox" },
     { name = "flet" },
+    { name = "flet-android-notifications" },
     { name = "flet-permission-handler" },
     { name = "flet-secure-storage" },
     { name = "garmin-fit-sdk" },
@@ -199,6 +212,7 @@ dev = [
 requires-dist = [
     { name = "dropbox", specifier = ">=12.0.2" },
     { name = "flet", specifier = "==0.86.1" },
+    { name = "flet-android-notifications", specifier = ">=0.10.0,<0.11" },
     { name = "flet-permission-handler", specifier = "==0.86.1" },
     { name = "flet-secure-storage", specifier = "==0.86.1" },
     { name = "garmin-fit-sdk", specifier = ">=21.208.0" },


### PR DESCRIPTION
## Summary
- Add optional Settings-driven auto-sync that polls enabled sources on a chosen interval and notifies when rides upload
- Share activity sync via `sync_runner` with an overlap lock so manual Sync and auto-sync cannot run concurrently
- On Android, keep the process alive with a foreground service while auto-sync is enabled; desktop only runs while the app is open
- Improve settings form layout so helper text wraps and fields stretch to full width

## Test plan
- [ ] Enable Auto-sync in Settings, pick an interval, confirm it runs without overlapping a manual Sync
- [ ] Verify OS notification appears when new rides upload
- [ ] Android: confirm sticky FGS notification while enabled; force-stop ends sync
- [ ] Desktop: confirm auto-sync stops when the app is closed
- [ ] `uv run pytest`
- [ ] Spot-check Settings helpers wrap cleanly on a narrow window